### PR TITLE
Prevent running aspects on analysis test targets

### DIFF
--- a/server/aspects/core.bzl
+++ b/server/aspects/core.bzl
@@ -69,8 +69,19 @@ def _get_forwarded_deps(target, ctx):
         return collect_targets_from_attrs(ctx.rule.attr, ["deps"])
     return []
 
+def _is_analysis_test(target):
+    """Returns if the target is an analysis test.
+
+    Rules created with analysis_test=True cannot create write actions, so the
+    aspect should skip them.
+    """
+    return AnalysisTestResultInfo in target
+
+
 def _bsp_target_info_aspect_impl(target, ctx):
     if target.label.name.endswith(".semanticdb"):
+        return []
+    if _is_analysis_test(target):
         return []
 
     rule_attrs = ctx.rule.attr

--- a/server/aspects/core.bzl
+++ b/server/aspects/core.bzl
@@ -1,3 +1,5 @@
+# Copyright 2019-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
 load("//aspects:extensions.bzl", "EXTENSIONS", "TOOLCHAINS")
 load("//aspects:utils/utils.bzl", "abs", "create_struct", "file_location", "get_aspect_ids", "update_sync_output_groups")
 

--- a/server/aspects/core.bzl
+++ b/server/aspects/core.bzl
@@ -78,9 +78,7 @@ def _is_analysis_test(target):
     return AnalysisTestResultInfo in target
 
 def _bsp_target_info_aspect_impl(target, ctx):
-    if target.label.name.endswith(".semanticdb"):
-        return []
-    if _is_analysis_test(target):
+    if target.label.name.endswith(".semanticdb") or _is_analysis_test(target):
         return []
 
     rule_attrs = ctx.rule.attr

--- a/server/aspects/core.bzl
+++ b/server/aspects/core.bzl
@@ -77,7 +77,6 @@ def _is_analysis_test(target):
     """
     return AnalysisTestResultInfo in target
 
-
 def _bsp_target_info_aspect_impl(target, ctx):
     if target.label.name.endswith(".semanticdb"):
         return []


### PR DESCRIPTION
Copied from https://github.com/bazelbuild/intellij/blob/0ea607f9f896c81daf8336dce56eec5c1af8a954/aspect/intellij_info_impl.bzl#L1093

There are errors we see during sync for analysis test targets:
```
Traceback (most recent call last):
	File "/home/brian.mcnamara/.cache/bazel/ed652f9edad89910c6aee0276fef72dc/external/bazelbsp_aspect/aspects/core.bzl", line 181, column 22, in _bsp_target_info_aspect_impl
		ctx.actions.write(info_file, create_struct(**info).to_proto())
Error in write: implementation function of a rule with analysis_test=true may not register actions. Analysis test rules may only return success/failure information via AnalysisTestResultInfo.
```