### PR TITLE
Remove id from TestSuite as its not specified in schema

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
@@ -38,8 +38,6 @@ data class TestSuite(
   val errors: Int,
   @JacksonXmlProperty(isAttribute = true)
   val time: Double,
-  @JacksonXmlProperty(isAttribute = true)
-  val id: Int,
   @JacksonXmlElementWrapper(useWrapping = false)
   @JacksonXmlProperty(localName = "testcase")
   val testcase: List<TestCase> = emptyList(),


### PR DESCRIPTION
As per https://windyroad.com.au/dl/Open%20Source/JUnit.xsd (referenced as part of https://bazel.build/reference/test-encyclopedia `XML_OUTPUT_FILE`), I do not see id as an attribute for testsuite