### PR TITLE
[fix] Make SourceRootGuesser a fallback for source root resolution in bazel-bsp instead of parent

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParser.kt
@@ -16,7 +16,7 @@ object JVMLanguagePluginParser {
     val sourcePackagePath = Paths.get(sourcePackage.replace(".", "/"))
     val sourceRootEndIndex = source.nameCount - sourcePackagePath.nameCount - 1
     return if (!source.parent.endsWith(sourcePackagePath)) {
-      source.parent
+      SourceRootGuesser.getSourcesRoot(source)
     } else {
       Paths.get("/").resolve(source.subpath(0, sourceRootEndIndex))
     }

--- a/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParserTest.kt
+++ b/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/sync/languages/JVMLanguagePluginParserTest.kt
@@ -123,4 +123,57 @@ class JVMLanguagePluginParserTest {
     // then
     calculatedSourceRoot shouldBe sourceDir
   }
+
+  @Test
+  fun `should return source dir for package name not matching the dir, but with 'src main java' within parent path`() {
+    // given
+
+    val fileContent =
+      """
+            |package com.example
+            |
+            |public class Test {
+            |}
+            |
+      """.trimMargin()
+
+    val sourceRoot = tempRoot.resolve("src/main/java")
+    val sourceDir = Files.createDirectories(sourceRoot.resolve("dir1/dir2/dir3/"))
+
+    val sourceFile = Files.createFile(sourceDir.resolve("File.java"))
+    sourceFile.writeText(fileContent)
+
+    // when
+    val calculatedSourceRoot = JVMLanguagePluginParser.calculateJVMSourceRoot(sourceFile)
+
+    // then
+    calculatedSourceRoot shouldBe sourceRoot
+  }
+
+  @Test
+  fun `should return source dir for Scala package object`() {
+    // given
+    val packageName = "dir1.dir2"
+    val packageObjectName = "dir3"
+    val fileContent =
+      """
+            |package $packageName
+            |
+            |package object $packageObjectName {
+            |}
+            |
+      """.trimMargin()
+
+    val sourceRoot = tempRoot.resolve("src/main/scala")
+    val sourceDir = Files.createDirectories(sourceRoot.resolve("dir1/dir2/dir3/"))
+
+    val sourceFile = Files.createFile(sourceDir.resolve("package.scala"))
+    sourceFile.writeText(fileContent)
+
+    // when
+    val calculatedSourceRoot = JVMLanguagePluginParser.calculateJVMSourceRoot(sourceFile)
+
+    // then
+    calculatedSourceRoot shouldBe sourceRoot
+  }
 }


### PR DESCRIPTION
Problem
----
Previously source roots would be resolved incorrectly in the following cases:

### Having `src/main/java` in subpath, but non-matching package statement 

E.g. for a file at `src/main/java/foo/bar` with the following content
```java
package foo.bar.buz

class Foo;
````
`bar` would be detected as a source root instead of `java`.

### Scala package objects

In Scala it's typical to have files like `package.scala`
```scala
package foo.bar

package object buz
```
at path `src/main/scala/foo/bar/buz`.
In this case `buz` would be detected as a source root instead of `scala`.

Solution
----

If source detection based on package statement fails, fallback to `SourceRootGuesser.getSourcesRoot` instead of falling back parent directory. It also fallbacks to parent in the end, but only if there is no sub-path like `**/{main/test/etc.}/{scala/java/etc.}`