### PR TITLE
Add run line markers only on elements with run/debug/test targets

### DIFF
--- a/plugin-bsp/src/main/kotlin/org/jetbrains/plugins/bsp/ui/gutters/BspJVMRunLineMarkerContributor.kt
+++ b/plugin-bsp/src/main/kotlin/org/jetbrains/plugins/bsp/ui/gutters/BspJVMRunLineMarkerContributor.kt
@@ -47,14 +47,13 @@ public class BspJVMRunLineMarkerContributor : RunLineMarkerContributor() {
         temporaryTargetUtils
           .getTargetsForFile(url, project)
           .mapNotNull { temporaryTargetUtils.getBuildTargetInfoForId(it) }
-          .filter { it.capabilities.canRun || it.capabilities.canTest || it.capabilities.canDebug }
       calculateLineMarkerInfo(targetInfos)
     }
 
   private fun calculateLineMarkerInfo(targetInfos: List<BuildTargetInfo>): Info? =
     targetInfos
+      .flatMap { it.calculateEligibleActions() }
       .takeIf { it.isNotEmpty() }
-      ?.flatMap { it.calculateEligibleActions() }
       ?.let {
         BspLineMakerInfo(
           text = "Run",

--- a/plugin-bsp/src/main/kotlin/org/jetbrains/plugins/bsp/ui/gutters/BspJVMRunLineMarkerContributor.kt
+++ b/plugin-bsp/src/main/kotlin/org/jetbrains/plugins/bsp/ui/gutters/BspJVMRunLineMarkerContributor.kt
@@ -47,14 +47,20 @@ public class BspJVMRunLineMarkerContributor : RunLineMarkerContributor() {
         temporaryTargetUtils
           .getTargetsForFile(url, project)
           .mapNotNull { temporaryTargetUtils.getBuildTargetInfoForId(it) }
+          .filter { it.capabilities.canRun || it.capabilities.canTest || it.capabilities.canDebug }
       calculateLineMarkerInfo(targetInfos)
     }
 
-  private fun calculateLineMarkerInfo(targetInfos: List<BuildTargetInfo>): Info =
-    BspLineMakerInfo(
-      text = "Run",
-      actions = targetInfos.flatMap { it.calculateEligibleActions() },
-    )
+  private fun calculateLineMarkerInfo(targetInfos: List<BuildTargetInfo>): Info? =
+    targetInfos
+      .takeIf { it.isNotEmpty() }
+      ?.flatMap { it.calculateEligibleActions() }
+      ?.let {
+        BspLineMakerInfo(
+          text = "Run",
+          actions = it,
+        )
+      }
 
   private fun BuildTargetInfo?.calculateEligibleActions(): List<AnAction> =
     if (this == null) {


### PR DESCRIPTION
This prevents run line markers being added to classes where no target exists that can be run/debug/test.

Fixes https://youtrack.jetbrains.com/issue/BAZEL-1112/BSP-overrides-runline-markers-for-other-plugins for our use case as the run line markers for the other plugin exist on files which do not have runnable targets