### PR TITLE
[fix] Parse Scala 3 diagnostics without id

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/Scala3CompilerDiagnosticParser.kt
@@ -8,7 +8,7 @@ object Scala3CompilerDiagnosticParser : Parser {
   private val DiagnosticHeader =
     """
       ^--\       # "-- " diagnostic start 
-      \[E\d+\]   # "[E008]" code 
+      (?:\[E\d+\])?   # "[E008]" optional explanation id
       ([^:]+): # (1) type of diagnostic
       ([^:]+):(\d+):(\d+) # (2) path, (3) line, (4) column
       [\s-]*$ # " -----------------" ending 

--- a/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
+++ b/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/diagnostics/DiagnosticsServiceTest.kt
@@ -543,6 +543,42 @@ class DiagnosticsServiceTest {
   }
 
   @Test
+  fun `parse scala 3 diagnostics without ExplanationID`() {
+    // given
+    val output =
+      """|-- Error: path/to/file.scala:27:10 
+         |27 |  verride type Env = MyEnv
+         |   |          ^^^^
+         |   |          end of statement expected but 'type' found
+         |-- Warning: path/to/file.scala:13:24 
+         |13 |import scala.concurrent.ExecutionContext
+         |   |                        ^^^^^^^^^^^^^^^^
+         |   |                        unused import
+      """.trimMargin()
+
+    // when
+    val diagnostics = extractDiagnostics(output, Label.parse("//project/src/main/scala/com/example/project:project"))
+
+    // then
+    val expected =
+      listOf(
+        publishDiagnosticsParams(
+          TextDocumentIdentifier("file:///user/workspace/path/to/file.scala"),
+          BuildTargetIdentifier("@//project/src/main/scala/com/example/project:project"),
+          errorDiagnostic(
+            Position(27, 10),
+            "Error\nend of statement expected but 'type' found",
+          ),
+          warningDiagnostic(
+            Position(13, 24),
+            "Warning\nunused import",
+          ),
+        ),
+      )
+    diagnostics shouldContainExactlyInAnyOrder expected
+  }
+
+  @Test
   fun `parse scala warnings`() {
     // given
     val output =


### PR DESCRIPTION
DiagnosticID is not always present in diagnostic messages of Scala compiler:
[MessageRendering.scala#L185](https://github.com/scala/scala3/blob/main/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala#L185)