### PR TITLE
[fix] fix issue with rules_oci

### DIFF
--- a/server/aspects/core.bzl
+++ b/server/aspects/core.bzl
@@ -160,6 +160,10 @@ def _bsp_target_info_aspect_impl(target, ctx):
     default_info = target[DefaultInfo]
     executable = default_info and default_info.files_to_run.executable != None
 
+    env = getattr(rule_attrs, "env", {})
+    if type(env) == "Target":
+        env = str(env.label)
+
     info = dict(
         id = str(target.label),
         kind = ctx.rule.kind,
@@ -168,7 +172,7 @@ def _bsp_target_info_aspect_impl(target, ctx):
         sources = sources,
         generated_sources = generated_sources,
         resources = resources,
-        env = getattr(rule_attrs, "env", {}),
+        env = env,
         env_inherit = getattr(rule_attrs, "env_inherit", []),
         executable = executable,
     )


### PR DESCRIPTION
rules_oci[1] is a replacement for rules_docker, it brings a lot of more Bazel idiomatic features to OCI image creation, for instance the env parameter instead of being a dictionary whose values gets stamped at build time, it takes a target that will get built when needed based on Bazel caching rules, and will then be used in the OCI image manifest.

Without this change then when the aspect gets evaluated to_proto fails with:
```
ERROR: <repo-path>/<target>/BUILD.bazel:3:18: in @@bazelbsp_aspect//aspects:core.bzl%bsp_target_info_aspect aspect on oci_image rule <some-label>:
Traceback (most recent call last):
	File "<local-path>/external/bazelbsp_aspect/aspects/core.bzl", line 195, column 64, in _bsp_target_info_aspect_impl
		ctx.actions.write(info_file, create_struct(**info).to_proto())
Error in to_proto: in struct field .env: in Target field .actions: at list index 0: got Action, want string, int, float, bool, or struct
```

With this change I'm taking an approach similar to id which is a label, if the type of the env parameter is Target, then resolve the label for it and use that instead.

[1] https://github.com/bazel-contrib/rules_oci/