### PR TITLE
Improve allModuleDependencies performance

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/DependencyMapper.kt
@@ -53,11 +53,17 @@ object DependencyMapper {
     val toResolve = mutableListOf<Label>()
     toResolve.addAll(module.directDependencies)
     val accumulator = HashSet<Library>()
+    val allSeenTargets = toResolve.toMutableSet()
     while (toResolve.isNotEmpty()) {
       val lib = project.libraries[toResolve.removeLast()]
       if (lib != null && !accumulator.contains(lib)) {
         accumulator.add(lib)
-        toResolve.addAll(lib.dependencies)
+        allSeenTargets.add(lib.label)
+        for (dep in lib.dependencies) {
+          if (allSeenTargets.add(dep)) {
+            toResolve.add(dep)
+          }
+        }
       }
     }
     return accumulator


### PR DESCRIPTION
For modules with a large number of targets where many targets depend on a common subset of targets, allModuleDependencies can have exponential runtime. This happens because duplicate entries can end up in `toResolve` from different sources.

Instead, make sure that we only process each target once.

Added a test that will timeout within 2 minutes if not optimized.