### PR TITLE
[fix] Running tests with debug | #BAZEL-768 Done

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
@@ -164,7 +164,7 @@ class ExecuteService(
   fun runWithDebug(cancelChecker: CancelChecker, params: RunWithDebugParams): RunResult {
     fun jdwpArgument(port: Int): String =
       // all used options are defined in https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html#Invocation
-      "--jvm_flag=-agentlib:jdwp=" +
+      "--wrapper_script_flag=--jvm_flag=-agentlib:jdwp=" +
         "transport=dt_socket," +
         "server=n," +
         "suspend=y," +


### PR DESCRIPTION
Related: https://youtrack.jetbrains.com/issue/BAZEL-1114/Debug-run-configuration-adds-jvmopt
Based on https://github.com/bazelbuild/bazel/blob/ff0bc4b06b2ea814244f1f181718fe404dfb1efa/src/tools/launcher/java_launcher.h#L44
It looks like the test wrapper expects this prefix since the arguments passed to the test-setup.sh are at the end of the argument list