### PR TITLE
[fix] Deps between tests and code use `//plugin-bazel/src` | #BAZEL-1308

### DIFF
--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazel/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazel/BUILD
@@ -6,5 +6,5 @@ kt_junit5_test(
     runtime_deps = [
         "//plugin-bsp:intellij-bsp",
     ],
-    deps = ["//plugin-bazel:intellij-bazel"],
+    deps = ["//plugin-bazel/src:intellij-bazel"],
 )

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/fixtures/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/fixtures/BUILD
@@ -6,7 +6,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     visibility = ["//plugin-bazel/src/test:__subpackages__"],
     deps = [
-        "//plugin-bazel:intellij-bazel",
+        "//plugin-bazel/src:intellij-bazel",
         "@maven//:io_kotest_kotest_assertions_api_jvm",
         "@maven//:io_kotest_kotest_assertions_core_jvm",
         "@maven//:io_kotest_kotest_assertions_shared_jvm",

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/lexer/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/lexer/BUILD
@@ -7,7 +7,7 @@ kt_intellij_junit4_test(
         "//plugin-bsp:intellij-bsp",
     ],
     deps = [
-        "//plugin-bazel:intellij-bazel",
+        "//plugin-bazel/src:intellij-bazel",
         "//plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/fixtures",
     ],
 )
@@ -19,7 +19,7 @@ kt_intellij_junit4_test(
         "//plugin-bsp:intellij-bsp",
     ],
     deps = [
-        "//plugin-bazel:intellij-bazel",
+        "//plugin-bazel/src:intellij-bazel",
         "//plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/fixtures",
     ],
 )

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/projectview/lexer/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/projectview/lexer/BUILD
@@ -7,7 +7,7 @@ kt_intellij_junit4_test(
         "//plugin-bsp:intellij-bsp",
     ],
     deps = [
-        "//plugin-bazel:intellij-bazel",
+        "//plugin-bazel/src:intellij-bazel",
         "//plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/fixtures",
     ],
 )

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/starlark/fixtures/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/starlark/fixtures/BUILD
@@ -6,7 +6,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     visibility = ["//plugin-bazel/src/test:__subpackages__"],
     deps = [
-        "//plugin-bazel:intellij-bazel",
+        "//plugin-bazel/src:intellij-bazel",
         "@maven//:io_kotest_kotest_assertions_api_jvm",
         "@maven//:io_kotest_kotest_assertions_core_jvm",
         "@maven//:io_kotest_kotest_assertions_shared_jvm",


### PR DESCRIPTION
 This is the suggestion made on the ticket, and it seems to work w.r.t source resolution.
 I can't tell how this will affect the overall build though (local plugin run seems to work fine).