### PR TITLE
[feature] Tune the .bazelrc file annotations | #BAZEL-1426

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/flags/BazelFlag.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/flags/BazelFlag.kt
@@ -12,6 +12,8 @@ sealed class Flag {
 
   data class Boolean(override val name: String) : Flag()
 
+  data class TriState(override val name: String) : Flag()
+
   data class Integer(override val name: String) : Flag()
 
   data class Path(override val name: String) : Flag()
@@ -41,7 +43,7 @@ sealed class Flag {
           .toPersistentMap()
     }
 
-    internal val KnownFlags.allFlags by object : LazyExtension<PersistentMap<String, Flag>, KnownFlags>() {
+    private val KnownFlags.allFlags by object : LazyExtension<PersistentMap<String, Flag>, KnownFlags>() {
       override fun initValue(o: KnownFlags): PersistentMap<String, Flag> =
         KnownFlags.declaredFieldsMap
           .values
@@ -63,7 +65,8 @@ fun knownFlagNames(pair: Pair<Flag, Option>): List<Pair<String, Flag>> {
 
   names =
     when (flag) {
-      is Flag.Boolean -> names.flatMap { it -> listOf("--$it", "--no$it") }
+      is Flag.Boolean -> names.flatMap { listOf("--$it", "--no$it") }
+      is Flag.TriState -> names.flatMap { listOf("--$it", "--no$it") }
       else -> names.map { "--$it" }
     }
 

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/flags/KnownFlags.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/flags/KnownFlags.kt
@@ -561,7 +561,7 @@ internal object KnownFlags {
   )
   @JvmField
   @Suppress("unused")
-  val experimentalUseWindowsSandbox = Flag.Unknown("experimentalUseWindowsSandbox")
+  val experimentalUseWindowsSandbox = Flag.TriState("experimentalUseWindowsSandbox")
 
   //   --experimental_windows_sandbox_path (a string; default: "BazelSandbox.exe")
   @Option(
@@ -2411,7 +2411,7 @@ internal object KnownFlags {
   )
   @JvmField
   @Suppress("unused")
-  val buildPythonZip = Flag.Unknown("buildPythonZip")
+  val buildPythonZip = Flag.TriState("buildPythonZip")
 
   //   --catalyst_cpus (comma-separated list of options; may be used multiple times)
   @Option(
@@ -2606,7 +2606,7 @@ internal object KnownFlags {
   )
   @JvmField
   @Suppress("unused")
-  val enableRunfiles = Flag.Unknown("enableRunfiles")
+  val enableRunfiles = Flag.TriState("enableRunfiles")
 
   //   --experimental_action_listener (a build target label; may be used multiple times)
   @Option(
@@ -6927,7 +6927,7 @@ internal object KnownFlags {
   )
   @JvmField
   @Suppress("unused")
-  val generateJsonTraceProfile = Flag.Unknown("generateJsonTraceProfile")
+  val generateJsonTraceProfile = Flag.TriState("generateJsonTraceProfile")
 
   //   --[no]heap_dump_on_oom (a boolean; default: "false")
   @Option(
@@ -8438,7 +8438,7 @@ internal object KnownFlags {
   )
   @JvmField
   @Suppress("unused")
-  val cacheTestResults = Flag.Unknown("cacheTestResults")
+  val cacheTestResults = Flag.TriState("cacheTestResults")
 
   //   --color (yes, no or auto; default: "auto")
   @Option(

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/highlighting/BazelrcHighlightingColors.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/highlighting/BazelrcHighlightingColors.kt
@@ -13,4 +13,7 @@ object BazelrcHighlightingColors {
   val COMMENT = createTextAttributesKey("BAZELRC_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
   val IDENTIFIER = createTextAttributesKey("BAZELRC_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
   val UNKNOWN_FLAG = createTextAttributesKey("BAZELRC_UNKNOWN_FLAG", CodeInsightColors.WRONG_REFERENCES_ATTRIBUTES)
+  val UNDOCUMENTED_FLAG = createTextAttributesKey("BAZELRC_UNDOCUMENTED_FLAG", CodeInsightColors.WARNINGS_ATTRIBUTES)
+  val DEPRECATED_FLAG = createTextAttributesKey("BAZELRC_DEPRECATED_FLAG", CodeInsightColors.DEPRECATED_ATTRIBUTES)
+  val NOOP_FLAG = createTextAttributesKey("BAZELRC_NOOP_FLAG", CodeInsightColors.NOT_USED_ELEMENT_ATTRIBUTES)
 }


### PR DESCRIPTION
   * adds more cases (renamed, missing, undocumented, hidden)
   * tweak the visuals
   * regen the database to know about tristate
   * take tristate into account when resolving

Some examples:

Using old flag name:
![image](https://github.com/user-attachments/assets/0564d227-31f0-46c0-80a0-f4d2842c22e4)

Unknown flag:
![image](https://github.com/user-attachments/assets/3210ae74-b79c-44e9-9337-41edee75b8ff)

No op:
![image](https://github.com/user-attachments/assets/7de72ee6-2201-47e6-ad69-aaa955a08b07)

Deprecated:
![image](https://github.com/user-attachments/assets/3512a23a-9fc4-4bdb-a62b-44f59bf15e9e)


