### PR TITLE
Process all testcases in each incomplete info suite

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
@@ -271,10 +271,11 @@ private class FallbackTestXmlParser(private var parentId: TaskId, private var bs
         else -> TestStatus.PASSED
       }
     val testSuiteData = JUnitStyleTestSuiteData(null, suite.systemOut, null)
-    val testCase = suite.testcase.firstOrNull()
 
     bspClientTestNotifier.startTest(suite.name, suiteTaskId)
-    testCase?.let { processIncompleteInfoCase(it, suiteTaskId.id, suiteStatus) }
+    suite.testcase.forEach { testCase ->
+      processIncompleteInfoCase(testCase, suiteTaskId.id, suiteStatus)
+    }
     bspClientTestNotifier.finishTest(
       suite.name,
       suiteTaskId,

--- a/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParserTest.kt
+++ b/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParserTest.kt
@@ -547,6 +547,67 @@ class TestXmlParserTest {
     }
   }
 
+  @Test
+  fun `junit5 - all failure, multiple testcase`(
+    @TempDir tempDir: Path,
+  ) {
+    val sampleContents =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+          <testsuite name="testsuite" tests="2" failures="0" errors="2" disabled="0" skipped="0" package="">
+              <properties/>
+              <testcase name="testFailure1" classname="org.jetbrains.simple.DoubleFailTest" time="0.02">
+                  <error message="first fail ==&gt; expected: &lt;true&gt; but was: &lt;false&gt;" type="org.opentest4j.AssertionFailedError">
+                      <![CDATA[org.opentest4j.AssertionFailedError: first fail ==> expected: <true> but was: <false>
+                      	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
+                      	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
+                      	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
+                      	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
+                      	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:210)
+                      	at org.jetbrains.simple.DoubleFailTest.testFailure1(DoubleFailTest.java:44)
+                      	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
+                      	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+                      	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+                      ]]>
+                  </error>
+              </testcase>
+              <testcase name="testFailure2" classname="org.jetbrains.simple.DoubleFailTest" time="0">
+                  <error message="second fail ==&gt; expected: &lt;true&gt; but was: &lt;false&gt;" type="org.opentest4j.AssertionFailedError">
+                      <![CDATA[org.opentest4j.AssertionFailedError: second fail ==> expected: <true> but was: <false>
+                      	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
+                      	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
+                      	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
+                      	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
+                      	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:210)
+                      	at org.jetbrains.simple.DoubleFailTest.testFailure2(DoubleFailTest.java:49)
+                      	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
+                      	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+                      	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+                      ]]>
+                  </error>
+              </testcase>
+          </testsuite>
+      </testsuites>
+      """.trimIndent()
+
+    val client = MockBuildClient()
+    val notifier = BspClientTestNotifier(client, "sample-origin")
+    val parentId = TaskId("sample-task")
+
+    // when
+    TestXmlParser(parentId, notifier).parseAndReport(writeTempFile(tempDir, sampleContents))
+
+    // then
+    client.taskStartCalls.size shouldBe 3
+    client.taskFinishCalls.size shouldBe 3
+
+    val expectedNames = listOf("testsuite", "testFailure1", "testFailure2")
+
+    client.taskFinishCalls.map { (it.data as TestFinish).displayName } shouldContainExactlyInAnyOrder expectedNames
+    client.taskStartCalls.map { it.taskId } shouldContainExactlyInAnyOrder client.taskFinishCalls.map { it.taskId }
+  }
+
   private fun writeTempFile(tempDir: Path, contents: String): String {
     val tempFile = tempDir.resolve("tempFile.xml").toFile()
     tempFile.writeText(contents)


### PR DESCRIPTION
Previously, only the first test case in an info suite would be processed which leads to only the first test per suite (class, for example) result being reported.

Added test fails on main, passes here.