### PR TITLE
Improved reporting of BEP runs with multiple test results

### DIFF
--- a/server/commons/src/main/kotlin/org/jetbrains/bsp/bazel/commons/Constants.java
+++ b/server/commons/src/main/kotlin/org/jetbrains/bsp/bazel/commons/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
   public static final List<String> SUPPORTED_LANGUAGES =
       ImmutableList.of(SCALA, JAVA, KOTLIN /*, CPP */);
   public static final String BAZEL_BUILD_COMMAND = "build";
+  public static final String BAZEL_TEST_COMMAND = "test";
   public static final String BUILD_FILE_NAME = "BUILD";
   public static final String WORKSPACE_FILE_NAME = "WORKSPACE";
   public static final String ASPECT_REPOSITORY = "bazelbsp_aspect";


### PR DESCRIPTION
Previously a new BSP `build/taskStart` and `build/taskFinish` event was triggered with the same build identifier for each test result within a single BEP task run. The result was only showing one of the tests in the IJ test report UI.

This was encountered using the `java_test_suite` rule from [`contrib_rules_jvm`](https://github.com/bazel-contrib/rules_jvm?tab=readme-ov-file#java_test_suite) which creates a Bazel [`test_suite`](https://bazel.build/reference/be/general#test_suite) wrapping many individual tests.

My solution was to track a test run from the beginning to end BEP events which seems solid. I moved tracking of event statuses into `BspClientTestNotifier` which feels somewhat strange, however a bunch of added state in `BspServer` also seemed strange. I will wait for feedback on this.

The TestReport now contains correct metrics for the number of tests executed, which was accidentally fixed by the above change. It tracks number of leaf tests, not including wrapping suites. This behavior was taken from what the IJ task report shows, not sure if suites should be included or not.