### PR TITLE
Run test case processing for coverage runs

### DIFF
--- a/server/commons/src/main/kotlin/org/jetbrains/bsp/bazel/commons/Constants.kt
+++ b/server/commons/src/main/kotlin/org/jetbrains/bsp/bazel/commons/Constants.kt
@@ -11,6 +11,7 @@ object Constants {
   val SUPPORTED_LANGUAGES: List<String> = listOf(SCALA, JAVA, KOTLIN)
   const val BAZEL_BUILD_COMMAND: String = "build"
   const val BAZEL_TEST_COMMAND: String = "test"
+  const val BAZEL_COVERAGE_COMMAND: String = "coverage"
   const val BUILD_FILE_NAME: String = "BUILD"
   const val WORKSPACE_FILE_NAME: String = "WORKSPACE"
   const val ASPECT_REPOSITORY: String = "bazelbsp_aspect"

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/BepServer.kt
@@ -216,7 +216,7 @@ class BepServer(
         startParams.data = task
       }
       bspClient.onBuildTaskStart(startParams)
-    } else if (event.started.command == Constants.BAZEL_TEST_COMMAND) {
+    } else if (event.started.command == Constants.BAZEL_TEST_COMMAND || event.started.command == Constants.BAZEL_COVERAGE_COMMAND) {
       if (originId == null) {
         return
       }


### PR DESCRIPTION
In https://github.com/JetBrains/hirschgarten/pull/132 there were some adjustments made that put the test result logic behind a conditional.

With the added explicit check for the started.command value, test case processing and reporting is no longer getting triggered for coverage runs.  The coverage report collecting also occurs among that logic, meaning that the coverage report also is not being sent to the client.

This change adds coverage back into this conditional, so all test case processing logic runs as usual.
