### PR TITLE
Split additional Bazel parameters before passing to command

### DIFF
--- a/bazel-steward.yaml
+++ b/bazel-steward.yaml
@@ -25,4 +25,4 @@ search-paths:
       - "exact:WORKSPACE.bzlmod"
   - kinds: bazel
     path-patterns:
-      - "exact:WORKSPACE.bzlmod"  # this means bazel updates will only look at this file
+      - "exact:WORKSPACE.bzlmod" # this means bazel updates will only look at this file

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
@@ -21,10 +21,10 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import org.jetbrains.bsp.bazel.bazelrunner.BazelProcessResult
 import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
+import org.jetbrains.bsp.bazel.bazelrunner.HasAdditionalBazelOptions
 import org.jetbrains.bsp.bazel.bazelrunner.HasEnvironment
 import org.jetbrains.bsp.bazel.bazelrunner.HasMultipleTargets
 import org.jetbrains.bsp.bazel.bazelrunner.HasProgramArguments
-import org.jetbrains.bsp.bazel.bazelrunner.HasAdditionalBazelOptions
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelFlag
 import org.jetbrains.bsp.bazel.logger.BspClientLogger
 import org.jetbrains.bsp.bazel.server.bep.BepServer
@@ -193,7 +193,7 @@ class ExecuteService(
       }
 
     bazelTestParamsData?.additionalBazelParams?.let { additionalParams ->
-       (command as HasAdditionalBazelOptions).additionalBazelOptions.addAll(additionalParams.split(" "))
+      (command as HasAdditionalBazelOptions).additionalBazelOptions.addAll(additionalParams.split(" "))
     }
 
     bazelTestParamsData?.testFilter?.let { testFilter ->

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/sync/ExecuteService.kt
@@ -24,6 +24,7 @@ import org.jetbrains.bsp.bazel.bazelrunner.BazelRunner
 import org.jetbrains.bsp.bazel.bazelrunner.HasEnvironment
 import org.jetbrains.bsp.bazel.bazelrunner.HasMultipleTargets
 import org.jetbrains.bsp.bazel.bazelrunner.HasProgramArguments
+import org.jetbrains.bsp.bazel.bazelrunner.HasAdditionalBazelOptions
 import org.jetbrains.bsp.bazel.bazelrunner.params.BazelFlag
 import org.jetbrains.bsp.bazel.logger.BspClientLogger
 import org.jetbrains.bsp.bazel.server.bep.BepServer
@@ -191,8 +192,8 @@ class ExecuteService(
         else -> bazelRunner.buildBazelCommand { test() }
       }
 
-    bazelTestParamsData?.additionalBazelParams?.let { additionalBazelParams ->
-      command.options.add(additionalBazelParams)
+    bazelTestParamsData?.additionalBazelParams?.let { additionalParams ->
+       (command as HasAdditionalBazelOptions).additionalBazelOptions.addAll(additionalParams.split(" "))
     }
 
     bazelTestParamsData?.testFilter?.let { testFilter ->


### PR DESCRIPTION
Resolving https://youtrack.jetbrains.com/issue/BAZEL-1584

Additional Bazel parameters are currently being passed for execution as a single argument, resulting in an unrecognized option error from Bazel.

Example: `... '--noprogress_in_terminal_title' '--my_flag_1 --my_flag_2' '--test_filter=com.example.sample' ...`

Instead, treat them as a whitespace-separated list so that multiple flags can be included in a single request.  This also leverages the HasAdditionalBazelOptions interface instead of adding them directly to options.