### PR TITLE
Restore `.bsp/bazelbsp.json` on install

### DIFF
--- a/server/executioncontext/installationcontext/BUILD
+++ b/server/executioncontext/installationcontext/BUILD
@@ -1,0 +1,9 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "installationcontext",
+    visibility = ["//visibility:public"],
+    exports = [
+        "//server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext",
+    ],
+)

--- a/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/BUILD
+++ b/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/BUILD
@@ -1,0 +1,17 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "installationcontext",
+    srcs = glob(["*.kt"]),
+    visibility = [
+        "//server/executioncontext/installationcontext:__pkg__",
+        "//server/executioncontext/installationcontext/src/test/kotlin/org/jetbrains/bsp/bazel/installationcontext:__pkg__",
+    ],
+    exports = [
+        "//server/executioncontext/api",
+    ],
+    deps = [
+        "//server/executioncontext/api",
+        "//server/executioncontext/projectview:parser",
+    ],
+)

--- a/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContext.kt
+++ b/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContext.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.bsp.bazel.installationcontext
+
+import org.jetbrains.bsp.bazel.executioncontext.api.ExecutionContext
+import java.nio.file.Path
+
+data class InstallationContext(
+  val javaPath: InstallationContextJavaPathEntity,
+  val debuggerAddress: InstallationContextDebuggerAddressEntity?,
+  val projectViewFilePath: Path,
+  val bazelWorkspaceRootDir: Path,
+) : ExecutionContext()

--- a/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContextDebuggerAddressEntity.kt
+++ b/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContextDebuggerAddressEntity.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.bsp.bazel.installationcontext
+
+import org.jetbrains.bsp.bazel.executioncontext.api.ExecutionContextSingletonEntity
+
+data class InstallationContextDebuggerAddressEntity(override val value: String) : ExecutionContextSingletonEntity<String>()

--- a/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContextJavaPathEntity.kt
+++ b/server/executioncontext/installationcontext/src/main/kotlin/org/jetbrains/bsp/bazel/installationcontext/InstallationContextJavaPathEntity.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.bsp.bazel.installationcontext
+
+import org.jetbrains.bsp.bazel.executioncontext.api.ExecutionContextSingletonEntity
+import java.nio.file.Path
+import java.nio.file.Paths
+
+data class InstallationContextJavaPathEntity(override val value: Path) : ExecutionContextSingletonEntity<Path>()
+
+object InstallationContextJavaPathEntityMapper {
+  private const val JAVA_HOME_PROPERTY_KEY = "java.home"
+
+  fun default(): InstallationContextJavaPathEntity = readFromSystemPropertyAndMapOrFailure()
+
+  private fun readFromSystemPropertyAndMapOrFailure(): InstallationContextJavaPathEntity =
+    readFromSystemPropertyAndMap()
+      ?: error(
+        "System property '$JAVA_HOME_PROPERTY_KEY' is not specified! " +
+          "Please install java and try to reinstall the server",
+      )
+
+  private fun readFromSystemPropertyAndMap(): InstallationContextJavaPathEntity? =
+    System
+      .getProperty(JAVA_HOME_PROPERTY_KEY)
+      ?.let(Paths::get)
+      ?.let(::appendJavaBinary)
+      ?.let(::map)
+
+  private fun appendJavaBinary(javaHome: Path): Path = javaHome.resolve("bin").resolve("java")
+
+  private fun map(rawJavaPath: Path): InstallationContextJavaPathEntity = InstallationContextJavaPathEntity(rawJavaPath)
+}

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BUILD
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BUILD
@@ -8,6 +8,7 @@ kt_jvm_library(
     visibility = ["//visibility:public"],
     deps = [
         "//commons/src/main/kotlin/org/jetbrains/bazel/commons/constants",
+        "//server/executioncontext/installationcontext",
         "//server/executioncontext/projectview:generator",
         "//server/executioncontext/projectview:parser",
         "//server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/cli",

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BazelBspEnvironmentCreator.kt
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BazelBspEnvironmentCreator.kt
@@ -1,9 +1,12 @@
 package org.jetbrains.bsp.bazel.install
 
+import ch.epfl.scala.bsp4j.BspConnectionDetails
 import java.nio.file.Path
 
-class BazelBspEnvironmentCreator(projectRootDir: Path) : EnvironmentCreator(projectRootDir) {
+class BazelBspEnvironmentCreator(projectRootDir: Path, private val discoveryDetails: BspConnectionDetails) :
+  EnvironmentCreator(projectRootDir) {
   override fun create() {
     createDotBazelBsp()
+    createDotBsp(discoveryDetails)
   }
 }

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BspConnectionDetailsCreator.kt
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/BspConnectionDetailsCreator.kt
@@ -1,0 +1,30 @@
+package org.jetbrains.bsp.bazel.install
+
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import org.jetbrains.bazel.commons.constants.Constants
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContext
+
+class BspConnectionDetailsCreator(installationContext: InstallationContext, private val produceTraceLog: Boolean) {
+  private val launcherArgumentCreator = LauncherArgumentCreator(installationContext)
+
+  fun create(): BspConnectionDetails =
+    BspConnectionDetails(
+      Constants.NAME,
+      calculateArgv(),
+      Constants.VERSION,
+      Constants.BSP_VERSION,
+      Constants.SUPPORTED_LANGUAGES,
+    )
+
+  private fun calculateArgv(): List<String> =
+    listOfNotNull(
+      launcherArgumentCreator.javaBinaryArgv(),
+      Constants.CLASSPATH_FLAG,
+      launcherArgumentCreator.classpathArgv(),
+      launcherArgumentCreator.debuggerConnectionArgv(),
+      Constants.SERVER_CLASS_NAME,
+      launcherArgumentCreator.bazelWorkspaceRootDir(),
+      launcherArgumentCreator.projectViewFilePathArgv(),
+      produceTraceLog.toString(),
+    )
+}

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/EnvironmentCreator.kt
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/EnvironmentCreator.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.bsp.bazel.install
 
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import com.google.gson.GsonBuilder
 import org.jetbrains.bazel.commons.constants.Constants
 import org.jetbrains.bsp.bazel.server.bsp.utils.FileUtils.writeIfDifferent
 import java.nio.file.FileSystems
@@ -86,6 +88,11 @@ abstract class EnvironmentCreator(private val projectRootDir: Path) {
     }
   }
 
+  protected fun createDotBsp(discoveryDetails: BspConnectionDetails) {
+    val dir = createDir(projectRootDir, Constants.DOT_BSP_DIR_NAME)
+    createBspDiscoveryDetailsFile(dir, discoveryDetails)
+  }
+
   private fun createDir(rootDir: Path, name: String): Path {
     val dir = rootDir.resolve(name)
     try {
@@ -93,5 +100,15 @@ abstract class EnvironmentCreator(private val projectRootDir: Path) {
     } catch (_: FileAlreadyExistsException) {
     }
     return dir
+  }
+
+  private fun createBspDiscoveryDetailsFile(dotBspDir: Path, discoveryDetails: BspConnectionDetails) {
+    val destinationBspDiscoveryFilePath = dotBspDir.resolve(Constants.BAZELBSP_JSON_FILE_NAME)
+    writeJsonToFile(destinationBspDiscoveryFilePath, discoveryDetails)
+  }
+
+  private fun <T> writeJsonToFile(destinationPath: Path, data: T) {
+    val fileContent = GsonBuilder().setPrettyPrinting().create().toJson(data)
+    Files.writeString(destinationPath, fileContent)
   }
 }

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/InstallationContextProvider.kt
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/InstallationContextProvider.kt
@@ -2,11 +2,29 @@ package org.jetbrains.bsp.bazel.install
 
 import org.jetbrains.bazel.commons.constants.Constants.DEFAULT_PROJECT_VIEW_FILE_NAME
 import org.jetbrains.bsp.bazel.install.cli.CliOptions
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContext
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContextDebuggerAddressEntity
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContextJavaPathEntity
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContextJavaPathEntityMapper
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isRegularFile
 
 object InstallationContextProvider {
+  fun createInstallationContext(cliOptions: CliOptions): InstallationContext =
+    InstallationContext(
+      javaPath =
+        cliOptions
+          .javaPath
+          ?.let { InstallationContextJavaPathEntity(it) } ?: InstallationContextJavaPathEntityMapper.default(),
+      debuggerAddress =
+        cliOptions
+          .debuggerAddress
+          ?.let { InstallationContextDebuggerAddressEntity(it) },
+      projectViewFilePath = calculateGeneratedProjectViewPath(cliOptions),
+      bazelWorkspaceRootDir = cliOptions.bazelWorkspaceRootDir,
+    )
+
   fun generateAndSaveProjectViewFileIfNeeded(cliOptions: CliOptions) {
     val generatedProjectViewFilePath = calculateGeneratedProjectViewPath(cliOptions)
     if (!generatedProjectViewFilePath.isFileExisted() || cliOptions.projectViewCliOptions != null) {

--- a/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/LauncherArgumentCreator.kt
+++ b/server/install/src/main/kotlin/org/jetbrains/bsp/bazel/install/LauncherArgumentCreator.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.bsp.bazel.install
+
+import org.jetbrains.bsp.bazel.installationcontext.InstallationContext
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class LauncherArgumentCreator(private val installationContext: InstallationContext) {
+  fun javaBinaryArgv(): String = installationContext.javaPath.value.toString()
+
+  fun classpathArgv(): String = mapClasspathToAbsolutePaths(readSystemProperty("java.class.path"))
+
+  private fun readSystemProperty(name: String): String =
+    System.getProperty(name) ?: throw NoSuchElementException("Could not read $name system property")
+
+  private fun mapClasspathToAbsolutePaths(systemPropertyClasspath: String): String =
+    systemPropertyClasspath
+      .split(File.pathSeparator)
+      .map(Paths::get)
+      .map(Path::toAbsolutePath)
+      .map(Path::normalize)
+      .joinToString(separator = File.pathSeparator, transform = Path::toString)
+
+  fun debuggerConnectionArgv(): String? =
+    installationContext
+      .debuggerAddress
+      ?.value
+      ?.let { "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$it" }
+
+  fun projectViewFilePathArgv(): String = installationContext.projectViewFilePath.toString()
+
+  fun bazelWorkspaceRootDir(): String = installationContext.bazelWorkspaceRootDir.toString()
+}

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/BUILD
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/BUILD
@@ -1,21 +1,21 @@
 load("@rules_sonatype//:defs.bzl", "sonatype_java_export")
 
 # Disabled because now server depends on IJ SDK
-# sonatype_java_export(
-#     name = "bsp",
-#     maven_coordinates = "org.jetbrains.bsp:bazel-bsp:3.2.0",
-#     maven_profile = "org.jetbrains",
-#     pom_template = "//server/server/src/main/resources:pom.xml",
-#     resources = ["//server/log4j_config"],
-#     visibility = ["//visibility:public"],
-#     runtime_deps = [
-#         "//server/commons",
-#         "//server/install:install-lib",
-#         "//server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server",
-#         "@server_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
-#         "@server_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
-#     ],
-# )
+sonatype_java_export(
+    name = "bsp",
+    maven_coordinates = "org.jetbrains.bsp:bazel-bsp:3.2.0",
+    maven_profile = "org.jetbrains",
+    pom_template = "//server/server/src/main/resources:pom.xml",
+    resources = ["//server/log4j_config"],
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "//server/commons",
+        "//server/install:install-lib",
+        "//server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server",
+        "@server_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@server_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+    ],
+)
 
 java_library(
     name = "bsp_export",


### PR DESCRIPTION
This was recently removed in 0b6f5fdf001880100. Adding it back just because this is a pretty important part of how a tool consuming a BSP implementation can generically start the server. Other BSP implementations (like SBT) also generate the JSON file.