### PR TITLE
[feature] Add quick fixes to old and no-op flags | #BAZEL-1704 Done

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/annotation/BazelrcFlagAnnotator.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/annotation/BazelrcFlagAnnotator.kt
@@ -16,6 +16,8 @@ import org.jetbrains.bazel.languages.bazelrc.flags.OptionMetadataTag
 import org.jetbrains.bazel.languages.bazelrc.highlighting.BazelrcHighlightingColors
 import org.jetbrains.bazel.languages.bazelrc.psi.BazelrcFlag
 import org.jetbrains.bazel.languages.bazelrc.psi.BazelrcLine
+import org.jetbrains.bazel.languages.bazelrc.quickfix.DeleteFlagUseFix
+import org.jetbrains.bazel.languages.bazelrc.quickfix.RenameFlagNameFix
 import kotlin.text.Regex
 
 val flagTokenPattern =
@@ -69,6 +71,7 @@ class BazelrcFlagAnnotator : Annotator {
           .range(element.textRange)
           .textAttributes(BazelrcHighlightingColors.NOOP_FLAG)
           .needsUpdateOnTyping()
+          .withFix(DeleteFlagUseFix(element, flag))
           .create()
 
       isDeprecated(flag, element) ->
@@ -85,7 +88,7 @@ class BazelrcFlagAnnotator : Annotator {
           .range(element.textRange)
           .textAttributes(BazelrcHighlightingColors.DEPRECATED_FLAG)
           .needsUpdateOnTyping()
-          // TODO(BAZEL-1704): Add an intention to fix
+          .withFix(RenameFlagNameFix(element, flag))
           .create()
 
       else -> {}

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/psi/BazelrcElementGenerator.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/psi/BazelrcElementGenerator.kt
@@ -1,0 +1,22 @@
+package org.jetbrains.bazel.languages.bazelrc.psi
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.impl.PsiFileFactoryImpl
+import com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.bazel.languages.bazelrc.BazelrcFileType
+import org.jetbrains.bazel.languages.bazelrc.BazelrcLanguage
+
+private const val DUMMY_FILENAME = "dummy.bazelrc"
+
+class BazelrcElementGenerator(val project: Project) {
+  private fun createDummyFile(contents: String): BazelrcFile {
+    val factory = PsiFileFactory.getInstance(project)
+    val virtualFile = LightVirtualFile(DUMMY_FILENAME, BazelrcFileType, contents)
+
+    return (factory as PsiFileFactoryImpl).trySetupPsiForFile(virtualFile, BazelrcLanguage, false, true) as BazelrcFile
+  }
+
+  fun createFlagName(flagName: String): PsiElement = createDummyFile("common --$flagName").lines[0].flags[0].name!!
+}

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/psi/BazelrcLine.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/psi/BazelrcLine.kt
@@ -8,8 +8,14 @@ import org.jetbrains.bazel.languages.bazelrc.elements.BazelrcTokenTypes
 class BazelrcLine(node: ASTNode) : BazelrcBaseElement(node) {
   override fun acceptVisitor(visitor: BazelrcElementVisitor) = visitor.visitLine(this)
 
-  val config: String? = this.findChildByType<PsiElement>(BazelrcTokenTypes.CONFIG)?.text
-  val command: String = this.findChildByType<PsiElement>(COMMAND_TOKENS)?.text ?: ""
+  val config: String?
+    get() = this.findChildByType<PsiElement>(BazelrcTokenTypes.CONFIG)?.text
+
+  val command: String
+    get() = this.findChildByType<PsiElement>(COMMAND_TOKENS)?.text ?: ""
+
+  val flags: Array<BazelrcFlag>
+    get() = this.findChildrenByClass(BazelrcFlag::class.java)
 
   companion object {
     val COMMAND_TOKENS = TokenSet.create(BazelrcTokenTypes.COMMAND)

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/DeleteFlagUseFix.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/DeleteFlagUseFix.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.bazel.languages.bazelrc.quickfix
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.codeInspection.util.IntentionFamilyName
+import com.intellij.codeInspection.util.IntentionName
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
+import org.jetbrains.bazel.languages.bazelrc.flags.Flag
+import org.jetbrains.bazel.languages.bazelrc.psi.BazelrcFlag
+
+class DeleteFlagUseFix(element: PsiElement, val flag: Flag) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+  override fun invoke(
+    project: Project,
+    file: PsiFile,
+    editor: Editor?,
+    startElement: PsiElement,
+    endElement: PsiElement,
+  ) {
+    startElement.parentOfType<BazelrcFlag>()?.delete()
+  }
+
+  override fun getText(): @IntentionName String = """Delete NO_OP flag use"""
+
+  override fun getFamilyName(): @IntentionFamilyName String = "Delete NO_OP flag declarations"
+}

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/RenameFlagNameFix.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/RenameFlagNameFix.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.bazel.languages.bazelrc.quickfix
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.codeInspection.util.IntentionFamilyName
+import com.intellij.codeInspection.util.IntentionName
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.jetbrains.bazel.languages.bazelrc.flags.Flag
+import org.jetbrains.bazel.languages.bazelrc.psi.BazelrcElementGenerator
+
+class RenameFlagNameFix(element: PsiElement, val flag: Flag) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+  override fun invoke(
+    project: Project,
+    file: PsiFile,
+    editor: Editor?,
+    startElement: PsiElement,
+    endElement: PsiElement,
+  ) {
+    val target =
+      when {
+        startElement.text.startsWith("--no") -> "no${flag.option.name}"
+        else -> flag.option.name
+      }
+
+    startElement.replace(BazelrcElementGenerator(project).createFlagName(target))
+  }
+
+  override fun getText(): @IntentionName String = """Replace with "${flag.option.name}" variant"""
+
+  override fun getFamilyName(): @IntentionFamilyName String = "Replace old flag names with new ones."
+}

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/commenter/BazelrcCommenterTest.kt
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/commenter/BazelrcCommenterTest.kt
@@ -2,6 +2,8 @@ package org.jetbrains.bazel.languages.bazelrc.commenter
 
 import com.google.idea.testing.runfiles.Runfiles
 import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.openapi.vfs.readText
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlin.io.path.pathString
 
@@ -13,11 +15,15 @@ class BazelrcCommenterTest : BasePlatformTestCase() {
   fun testUncomment() = doTest()
 
   private fun doTest() {
+    VfsRootAccess.allowRootAccess(this.testRootDisposable, this.testDataPath)
+
     val name = getTestName(false)
-    val source = "$name.bazelrc"
-    myFixture.configureByFile(source)
+
+    myFixture.configureByFile("$name.bazelrc")
+
     myFixture.performEditorAction(IdeActions.ACTION_COMMENT_LINE)
-    val result = "${name}Result.bazelrc"
-    myFixture.checkResultByFile(result)
+
+    val result = myFixture.copyFileToProject("${name}Result.bazelrc")
+    myFixture.checkResult(result.readText())
   }
 }

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/BUILD
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/BUILD
@@ -1,0 +1,8 @@
+load("@//rules/testing:intellij.bzl", "kt_intellij_junit4_test")
+
+kt_intellij_junit4_test(
+    name = "BazelrcQuickFixTest",
+    src = "BazelrcQuickFixTest.kt",
+    data = ["//plugin-bazel/src/test/testData/bazelrc/quickfix"],
+    deps = ["//plugin-bazel:intellij-bazel"],
+)

--- a/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/BazelrcQuickFixTest.kt
+++ b/plugin-bazel/src/test/kotlin/org/jetbrains/bazel/languages/bazelrc/quickfix/BazelrcQuickFixTest.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.bazel.languages.bazelrc.quickfix
+
+import com.google.idea.testing.runfiles.Runfiles
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlin.io.path.pathString
+
+class BazelrcQuickFixTest : BasePlatformTestCase() {
+  override fun getTestDataPath(): String = Runfiles.runfilesPath("/plugin-bazel/src/test/testData/bazelrc/quickfix/").pathString
+
+  fun testDeleteNoOpFlag() = doTest()
+
+  fun testReplaceDeprecatedFlag() = doTest()
+
+  fun testReplaceNegatedDeprecatedFlag() = doTest()
+
+  private fun doTest() {
+    VfsRootAccess.allowRootAccess(this.testRootDisposable, this.testDataPath)
+
+    val name = getTestName(false)
+
+    myFixture.configureByFile("$name.bazelrc")
+    myFixture.doHighlighting()
+
+    myFixture.launchAction(myFixture.findSingleIntention(""))
+
+    myFixture.checkResultByFile("${name}Result.bazelrc")
+  }
+}

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/BUILD
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "quickfix",
+    srcs = glob(["*.bazelrc"]),
+    visibility = ["//plugin-bazel/src/test:__subpackages__"],
+)

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/DeleteNoOpFlag.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/DeleteNoOpFlag.bazelrc
@@ -1,0 +1,1 @@
+common --<caret>expand_configs_in_place --ASDF

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/DeleteNoOpFlagResult.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/DeleteNoOpFlagResult.bazelrc
@@ -1,0 +1,1 @@
+common  --ASDF

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceDeprecatedFlag.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceDeprecatedFlag.bazelrc
@@ -1,0 +1,1 @@
+common <caret>--experimental_allow_tags_propagation

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceDeprecatedFlagResult.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceDeprecatedFlagResult.bazelrc
@@ -1,0 +1,1 @@
+common --incompatible_allow_tags_propagation

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceNegatedDeprecatedFlag.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceNegatedDeprecatedFlag.bazelrc
@@ -1,0 +1,1 @@
+common <caret>--noexperimental_allow_tags_propagation

--- a/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceNegatedDeprecatedFlagResult.bazelrc
+++ b/plugin-bazel/src/test/testData/bazelrc/quickfix/ReplaceNegatedDeprecatedFlagResult.bazelrc
@@ -1,0 +1,1 @@
+common --noincompatible_allow_tags_propagation


### PR DESCRIPTION
Add some quick fixes to deprecated and old flag names. With tests 

This still uses the 7.4.1 flags db so it might be incorrect on newer bazel. I need to get access to the bazel version in order to use a accurate db.