### PR TITLE
Don't mark non-top-level elements with `_` prefix as unused

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/starlark/annotation/StarlarkDeclarationAnnotator.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/starlark/annotation/StarlarkDeclarationAnnotator.kt
@@ -41,6 +41,8 @@ class StarlarkDeclarationAnnotator : StarlarkAnnotator() {
     val scope =
       if (element.isTopLevelTarget() || element.isTopLevelFunction()) {
         element.useScope
+      } else if (((element as? StarlarkNamedElement)?.name ?: "").startsWith("_")) {
+        return false
       } else {
         GlobalSearchScope.fileScope(element.containingFile)
       }

--- a/plugin-bazel/src/test/testData/starlark/annotation/UnusedDeclarationTestData.bzl
+++ b/plugin-bazel/src/test/testData/starlark/annotation/UnusedDeclarationTestData.bzl
@@ -39,3 +39,7 @@ def new_scope():
         x + y
 
 new_scope()
+
+def <weak_warning descr="Function \"_my_func_impl\" is never used">_my_func_impl</weak_warning>(_target, ctx, _):
+    _foo, some_val = some(ctx)
+    return some_val


### PR DESCRIPTION
Using `_` as a prefix of an identifier that isn't top-level indicates that it is expected to be unused.