### PR TITLE
[Add new metrics] Add project name to bazel sync metric collection

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -56,7 +56,9 @@ private val log = logger<ProjectSyncTask>()
 class ProjectSyncTask(private val project: Project) {
   suspend fun sync(syncScope: ProjectSyncScope, buildProject: Boolean) {
     if (project.isTrusted()) {
-      bspTracer.spanBuilder("bsp.sync.project.ms").useWithScope {
+      bspTracer.spanBuilder("bsp.sync.project.ms")
+        .setAttribute("project.name", project.name)
+        .useWithScope {
         var syncAlreadyInProgress = false
         try {
           log.debug("Starting sync project task")

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -56,7 +56,8 @@ private val log = logger<ProjectSyncTask>()
 class ProjectSyncTask(private val project: Project) {
   suspend fun sync(syncScope: ProjectSyncScope, buildProject: Boolean) {
     if (project.isTrusted()) {
-      bspTracer.spanBuilder("bsp.sync.project.ms")
+      bspTracer
+        .spanBuilder("bsp.sync.project.ms")
         .setAttribute("project.name", project.name)
         .useWithScope {
         var syncAlreadyInProgress = false

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -60,68 +60,68 @@ class ProjectSyncTask(private val project: Project) {
         .spanBuilder("bsp.sync.project.ms")
         .setAttribute("project.name", project.name)
         .useWithScope {
-        var syncAlreadyInProgress = false
-        try {
-          log.debug("Starting sync project task")
-          project.syncConsole.startTask(
-            taskId = PROJECT_SYNC_TASK_ID,
-            title = BazelPluginBundle.message("console.task.sync.title"),
-            message = BazelPluginBundle.message("console.task.sync.in.progress"),
-            cancelAction = {
-              SyncStatusService.getInstance(project).cancel()
-              coroutineContext.cancel()
-            },
-            redoAction = { sync(syncScope, buildProject) },
-          )
+          var syncAlreadyInProgress = false
+          try {
+            log.debug("Starting sync project task")
+            project.syncConsole.startTask(
+              taskId = PROJECT_SYNC_TASK_ID,
+              title = BazelPluginBundle.message("console.task.sync.title"),
+              message = BazelPluginBundle.message("console.task.sync.in.progress"),
+              cancelAction = {
+                SyncStatusService.getInstance(project).cancel()
+                coroutineContext.cancel()
+              },
+              redoAction = { sync(syncScope, buildProject) },
+            )
 
-          preSync()
-          doSync(syncScope, buildProject)
+            preSync()
+            doSync(syncScope, buildProject)
 
-          project.syncConsole.finishTask(PROJECT_SYNC_TASK_ID, BazelPluginBundle.message("console.task.sync.success"))
-        } catch (e: CancellationException) {
-          project.syncConsole.finishTask(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.cancelled"),
-            SkippedResultImpl(),
-          )
-          throw e
-        } catch (_: SyncAlreadyInProgressException) {
-          syncAlreadyInProgress = true
-        } catch (_: SyncPartialFailureException) {
-          project.syncConsole.addWarnMessage(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.partialsuccess"),
-          )
-          project.syncConsole.finishTask(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.partialsuccess"),
-            SuccessResultImpl(true),
-          )
-        } catch (_: SyncFatalFailureException) {
-          project.syncConsole.finishTask(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.fatalfailure"),
-            FailureResultImpl(),
-          )
-        } catch (e: ProjectViewParser.ImportNotFound) {
-          val projectViewFile = project.bazelProjectSettings.projectViewPath.toString()
-          project.syncConsole.finishTask(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.failed"),
-            FailureResultImpl(BazelPluginBundle.message("console.task.sync.import.fail", e.file, projectViewFile)),
-          )
-        } catch (e: Exception) {
-          project.syncConsole.finishTask(
-            PROJECT_SYNC_TASK_ID,
-            BazelPluginBundle.message("console.task.sync.failed"),
-            FailureResultImpl(e),
-          )
-        } finally {
-          if (!syncAlreadyInProgress) {
-            postSync()
+            project.syncConsole.finishTask(PROJECT_SYNC_TASK_ID, BazelPluginBundle.message("console.task.sync.success"))
+          } catch (e: CancellationException) {
+            project.syncConsole.finishTask(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.cancelled"),
+              SkippedResultImpl(),
+            )
+            throw e
+          } catch (_: SyncAlreadyInProgressException) {
+            syncAlreadyInProgress = true
+          } catch (_: SyncPartialFailureException) {
+            project.syncConsole.addWarnMessage(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.partialsuccess"),
+            )
+            project.syncConsole.finishTask(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.partialsuccess"),
+              SuccessResultImpl(true),
+            )
+          } catch (_: SyncFatalFailureException) {
+            project.syncConsole.finishTask(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.fatalfailure"),
+              FailureResultImpl(),
+            )
+          } catch (e: ProjectViewParser.ImportNotFound) {
+            val projectViewFile = project.bazelProjectSettings.projectViewPath.toString()
+            project.syncConsole.finishTask(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.failed"),
+              FailureResultImpl(BazelPluginBundle.message("console.task.sync.import.fail", e.file, projectViewFile)),
+            )
+          } catch (e: Exception) {
+            project.syncConsole.finishTask(
+              PROJECT_SYNC_TASK_ID,
+              BazelPluginBundle.message("console.task.sync.failed"),
+              FailureResultImpl(e),
+            )
+          } finally {
+            if (!syncAlreadyInProgress) {
+              postSync()
+            }
           }
         }
-      }
     }
   }
 


### PR DESCRIPTION
# Problem
When analysing Bazel sync performance metrics in OpenTelemetry/Jaeger, it's difficult to distinguish between syncs from different projects when multiple IntelliJ projects are open. The `bsp.sync.project.ms` span doesn't include any project identification, making it challenging to:

- Filter traces by specific projects
- Compare sync performance across different projects
- Analysing project-specific sync issues

# Solution
Added a project.name attribute to the bsp.sync.project.ms span in ProjectSyncTask. This enhancement provides better observability by:

- Clearly identifying which project each sync operation belongs to
- Enabling project-based filtering in Jaeger UI (e.g., project.name="MyProject")
- Improving analysing capabilities when investigating sync performance issues

# Changes
Modified `ProjectSyncTask.sync()` to include `.setAttribute("project.name", project.name)` when creating the span