### PR TITLE
Enhance ImportRunConfigurationsSyncHook

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
@@ -24,6 +24,7 @@ import org.jetbrains.bazel.sync.withSubtask
 import java.nio.file.Path
 
 private const val GOOGLE_BAZEL_RUN_CONFIG_TYPE = "BlazeCommandRunConfigurationType"
+private const val SHELL_SCRIPT_RUN_CONFIG_TYPE = "ShConfigurationType"
 
 internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
   private val log = logger<ImportRunConfigurationsSyncHook>()
@@ -61,12 +62,12 @@ internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
 
   private fun importRunConfiguration(project: Project, runConfigurationPath: Path): RunnerAndConfigurationSettings? {
     val runConfigurationXml = getConfigurationElement(JDOMUtil.load(runConfigurationPath)) ?: return null
-    val settings =
-      if (checkNotNull(runConfigurationXml.getAttributeValue("type")) == GOOGLE_BAZEL_RUN_CONFIG_TYPE) {
-        loadGoogleBazelRunConfiguration(project, runConfigurationXml)
-      } else {
-        loadRunConfigurationXmlNormally(project, runConfigurationXml)
-      }
+    val configurationType = checkNotNull(runConfigurationXml.getAttributeValue("type"))
+    val settings = when (configurationType) {
+      GOOGLE_BAZEL_RUN_CONFIG_TYPE -> loadGoogleBazelRunConfiguration(project, runConfigurationXml)
+      SHELL_SCRIPT_RUN_CONFIG_TYPE -> loadShellScriptRunConfiguration(project, runConfigurationXml)
+      else -> loadRunConfigurationXmlNormally(project, runConfigurationXml)
+    }
     return settings
   }
 
@@ -125,6 +126,40 @@ internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
     }
 
     return settings
+  }
+
+  private fun loadShellScriptRunConfiguration(project: Project, runConfigurationXml: Element): RunnerAndConfigurationSettings {
+    // Create a copy of the XML element to modify it
+    val modifiedXml = runConfigurationXml.clone()
+    // Apply replaceProjectDir to the specified shell script configuration fields
+    modifiedXml.children.filter { it.name == "option" }.forEach { option ->
+      when (option.getAttributeValue("name")) {
+        "SCRIPT_TEXT" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_PATH" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_OPTIONS" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_WORKING_DIRECTORY" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+      }
+    }
+
+    // Load the modified configuration normally
+    val runManager = RunManagerImpl.getInstanceImpl(project)
+    return runManager.loadConfiguration(modifiedXml, false)
   }
 
   /**


### PR DESCRIPTION
This patch includes: 
1. Support ShConfigurationType and apply replaceProjectDir to respective fields in the type to patch the $PROJECT_DIR$ diff
2. Support reading multiple blaze-user-flag from the Google Plugin
3. Support reading pre-run tasks from Google Plugin while filtering out the Google Plugin specific task

For the following configuration generated from Google plugin, 
```
<configuration name="Some Bazel Config" type="BlazeCommandRunConfigurationType" factoryName="Bazel Command">
  <blaze-settings handler-id="BlazeJavaRunConfigurationHandlerProvider" kind="java_binary" blaze-command="run" keep-in-sync="true">
    <blaze-target>//A:target</blaze-target>
    <blaze-user-flag>--run_under=//A:some_bzl</blaze-user-flag>
    <blaze-user-flag>--//A:some_param=True</blaze-user-flag>
    <env_state>
      <envs>
        <env name="SOME_ID" value="0" />
        <env name="PORT_PREFIX" value="74" />
      </envs>
    </env_state>
  </blaze-settings>
  <method v="2">
    <option name="RunConfigurationTask" enabled="true" run_configuration_name="some sh task" run_configuration_type="ShConfigurationType" />
    <option name="Blaze.BeforeRunTask" enabled="true" />
  </method>
</configuration>
```
The imported task:

<img width="1203" height="582" alt="Screenshot 2025-10-27 at 1 33 08 PM" src="https://github.com/user-attachments/assets/68c1d358-8e33-4a1a-ba79-471b608f459d" />


