### PR TITLE
BAZEL-2666 Add support for scala compiler plugins

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/workspace/languages/scala/ScalaLanguagePlugin.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/sync/workspace/languages/scala/ScalaLanguagePlugin.kt
@@ -15,6 +15,8 @@ import org.jetbrains.bazel.sync.workspace.languages.jvm.JVMPackagePrefixResolver
 import org.jetbrains.bazel.workspacecontext.WorkspaceContext
 import org.jetbrains.bsp.protocol.ScalaBuildTarget
 import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.text.removePrefix
 
 class ScalaLanguagePlugin(
   private val javaLanguagePlugin: JavaLanguagePlugin,
@@ -56,11 +58,23 @@ class ScalaLanguagePlugin(
       scalaVersion = sdk.version,
       sdkJars = sdk.compilerJars,
       jvmBuildTarget = javaLanguagePlugin.createBuildTargetData(context, target),
-      scalacOptions = target.scalaTargetInfo.scalacOptsList,
+      scalacOptions = target.scalaTargetInfo.scalacOptsList.map(::transformPluginPath),
     )
   }
+
+  private fun transformPluginPath(option: String): String =
+    if (option.startsWith(SCALAC_PLUGIN_PREFIX)) {
+      val pluginPath = Paths.get(option.removePrefix(SCALAC_PLUGIN_PREFIX))
+      "$SCALAC_PLUGIN_PREFIX${bazelPathsResolver.resolveOutput(pluginPath)}"
+    } else {
+      option
+    }
 
   override fun getSupportedLanguages(): Set<LanguageClass> = setOf(LanguageClass.SCALA)
 
   override fun resolveJvmPackagePrefix(source: Path): String? = packageResolver.calculateJvmPackagePrefix(source, true)
+
+  companion object {
+    private val SCALAC_PLUGIN_PREFIX = "-Xplugin:"
+  }
 }

--- a/server/resources/aspects/rules/scala/scala_info.bzl.template
+++ b/server/resources/aspects/rules/scala/scala_info.bzl.template
@@ -48,6 +48,16 @@ def extract_scalatest_classpath(rule_attr):
         extract_from_attr("_scalatest_reporter")
     )
 
+def get_plugins(rule_attr):
+    result = []
+    plugins = getattr(rule_attr, "plugins", [])
+    for plugin in plugins:
+        if JavaInfo in plugin:
+            jars = getattr(plugin[JavaInfo], "full_compile_jars", depset()).to_list()
+            for f in map(file_location, jars):
+                result.append("-Xplugin:%s/%s" % (f.root_execution_path_fragment, f.relative_path))
+    return result
+
 def extract_scala_info(target, ctx, output_groups, **kwargs):
     kind = ctx.rule.kind
     if not kind.startswith("scala_") and not kind.startswith("thrift_"):
@@ -71,7 +81,8 @@ def extract_scala_info(target, ctx, output_groups, **kwargs):
                     update_sync_output_groups(output_groups, "bsp-sync-artifact", depset(compiler_classpath))
     else:
         common_scalac_opts = []
-    scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])
+
+    scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", []) + get_plugins(rule_attr)
 
     scala_info["scalatest_classpath"] = extract_scalatest_classpath(rule_attr)
 


### PR DESCRIPTION
This PR adds support for Scalac compiler plugins (e.g., better-monadic-for) with automatic path resolution.