### PR TITLE
fix(bsp): Bazel 7.6.1 + WORKSPACE: batch-retry show_repo on WORKSPACE bad-repo errors

### DIFF
--- a/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/ModuleResolver.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/ModuleResolver.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bazel.bazelrunner
 
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.bazel.commons.BazelInfo
 import org.jetbrains.bazel.commons.gson.bazelGson
 import org.jetbrains.bazel.workspacecontext.WorkspaceContext
@@ -162,17 +163,40 @@ internal class ModuleResolver(
         .waitAndGetResult()
     if (bazelInfo.isWorkspaceEnabled && processResult.isNotSuccess) {
       // work around https://github.com/bazelbuild/bazel/issues/28601
-      // As we cannot reliably determine which repositories `bazel mod show_repo` is willing to resolve,
-      // we have to accept failure. However, to get the maximal amount of information possible, we should
-      // ask for each repository individually.
+      // Parse the error to identify the bad repo and retry the batch without it,
+      // falling back to per-repo resolution for unrecognized errors.
+      val badRepo = extractBadRepoFromError(processResult)
+      if (badRepo != null && moduleNames.size > 1 && badRepo in moduleNames) {
+        val remaining = moduleNames.filter { it != badRepo }
+        val retryResults = resolveModules(remaining, bazelInfo)
+        return retryResults + mapOf(badRepo to null)
+      }
       if (moduleNames.size == 1) {
         // Failure of a request asking for a single repository, so we just answer that we don't know.
         return mapOf(moduleNames[0] to null)
       }
-      return moduleNames.map { resolveModules(listOf(it), bazelInfo) }.reduceOrNull { acc, result -> acc + result } ?: emptyMap()
+      return resolveModulesIndividually(moduleNames, bazelInfo)
     }
 
     return moduleOutputParser.parseShowRepoResults(processResult, json_output)
+  }
+
+  private suspend fun resolveModulesIndividually(moduleNames: List<String>, bazelInfo: BazelInfo): Map<String, ShowRepoResult?> =
+    moduleNames.map { resolveModules(listOf(it), bazelInfo) }.reduceOrNull { acc, result -> acc + result } ?: emptyMap()
+
+  companion object {
+    private val BAD_REPO_PATTERNS = listOf(
+      Regex("""In repo argument ([^\s:]+): no such repo\."""),
+      Regex("""In repo argument ([^\s:]+): No repo visible as .* from @.* repository .*"""),
+      Regex("""In repo argument ([^\s:]+): Module .* does not exist in the dependency graph\..*"""),
+    )
+
+    @VisibleForTesting
+    internal fun extractBadRepoFromError(processResult: BazelProcessResult): String? =
+      processResult.stderrLines
+        .firstNotNullOfOrNull { line ->
+          BAD_REPO_PATTERNS.firstNotNullOfOrNull { it.find(line)?.groupValues?.get(1) }
+        }
   }
 
   val gson = bazelGson

--- a/pluginTests/test/org/jetbrains/bazel/bazelrunner/ModuleResolverTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/bazelrunner/ModuleResolverTest.kt
@@ -4,8 +4,18 @@ import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.bazel.bazelrunner.outputs.OutputCollector
+import org.jetbrains.bazel.commons.BazelInfo
+import org.jetbrains.bazel.commons.BazelRelease
+import org.jetbrains.bazel.sync.workspace.projectTree.BazelRunnerSpyStubbingHelper
+import org.jetbrains.bazel.workspacecontext.WorkspaceContext
+import org.jetbrains.bsp.protocol.TaskGroupId
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.`when`
+import java.nio.file.Path
 
 class ModuleResolverTest {
   fun makeOutputCollector(lines: String): OutputCollector =
@@ -14,6 +24,79 @@ class ModuleResolverTest {
     }
 
   val moduleOutputParser = ModuleOutputParser()
+  private val tempDir = Path.of(System.getProperty("java.io.tmpdir"))
+  private val taskId = TaskGroupId.EMPTY.task("module-resolver-test")
+  private val workspaceContext =
+    WorkspaceContext(
+      targets = emptyList(),
+      directories = emptyList(),
+      buildFlags = emptyList(),
+      syncFlags = emptyList(),
+      debugFlags = emptyList(),
+      bazelBinary = null,
+      allowManualTargetsSync = false,
+      importDepth = 0,
+      enabledRules = emptyList(),
+      ideJavaHomeOverride = null,
+      shardSync = false,
+      targetShardSize = 0,
+      shardingApproach = null,
+      importRunConfigurations = emptyList(),
+      gazelleTarget = null,
+      indexAllFilesInDirectories = false,
+      pythonCodeGeneratorRuleNames = emptyList(),
+      importIjars = false,
+      deriveInstrumentationFilterFromTargets = false,
+      indexAdditionalFilesInDirectories = emptyList(),
+      preferClassJarsOverSourcelessJars = false,
+    )
+
+  private fun makeResult(stdout: String = "", stderr: String = "", exitCode: Int = 0): BazelProcessResult =
+    BazelProcessResult(makeOutputCollector(stdout), makeOutputCollector(stderr), exitCode)
+
+  private fun bazelInfo(workspaceEnabled: Boolean = true): BazelInfo =
+    BazelInfo(
+      execRoot = tempDir,
+      outputBase = tempDir,
+      workspaceRoot = tempDir,
+      bazelBin = tempDir,
+      release = BazelRelease(7, 6),
+      isBzlModEnabled = true,
+      isWorkspaceEnabled = workspaceEnabled,
+      externalAutoloads = emptyList(),
+    )
+
+  private fun createResolver(vararg processResults: BazelProcessResult): ModuleResolver {
+    val runner = spy(BazelRunner(null, tempDir))
+    val process = mock(BazelProcess::class.java)
+
+    runBlocking {
+      `when`(process.waitAndGetResult()).thenReturn(*processResults)
+    }
+
+    BazelRunnerSpyStubbingHelper.stubRunBazelCommand(runner, process)
+    return ModuleResolver(runner, workspaceContext, taskId)
+  }
+
+  private fun localRepositoryStanza(repoArgument: String, repoName: String, path: String): String =
+    """
+      ## $repoArgument:
+      # <builtin>
+      local_repository(
+        name = "$repoName",
+        path = "$path",
+      )
+    """.trimIndent()
+
+  private fun httpArchiveStanza(repoArgument: String, repoName: String, url: String): String =
+    """
+      ## $repoArgument:
+      # <builtin>
+      http_archive(
+        name = "$repoName",
+        urls = ["$url"],
+      )
+    """.trimIndent()
 
   @Test
   fun `should throw on failed show repo invocation`() {
@@ -173,6 +256,145 @@ class ModuleResolverTest {
       "rules_kotlin@2.2.2" to ShowRepoResult.HttpArchiveRepository("rules_kotlin+", listOf("https://github.com/bazelbuild/rules_kotlin/releases/download/v2.2.2/rules_kotlin-v2.2.2.tar.gz"))
     )
 
+  }
+
+  @Test
+  fun `should correctly extract bad repo from error message`() {
+    val stderr =
+      "ERROR: In repo argument maven: Module maven does not exist in the dependency graph." +
+      "(Note that unused modules cannot be used here). Type 'bazel help mod' for syntax and help."
+    val result = BazelProcessResult(makeOutputCollector(""), makeOutputCollector(stderr), 2)
+
+    val badRepo = ModuleResolver.extractBadRepoFromError(result)
+    badRepo shouldBe "maven"
+  }
+
+  @Test
+  fun `should return null when error message has no repo argument`() {
+    val stderr = "ERROR: some unrelated bazel error"
+    val result = BazelProcessResult(makeOutputCollector(""), makeOutputCollector(stderr), 1)
+
+    val badRepo = ModuleResolver.extractBadRepoFromError(result)
+    badRepo shouldBe null
+  }
+
+  @Test
+  fun `should extract repo with @@ prefix from error`() {
+    val stderr =
+      "ERROR: In repo argument @@some_workspace_repo: Module @@some_workspace_repo does not exist in the dependency graph." +
+      "(Note that unused modules cannot be used here). Type 'bazel help mod' for syntax and help."
+    val result = BazelProcessResult(makeOutputCollector(""), makeOutputCollector(stderr), 2)
+
+    val badRepo = ModuleResolver.extractBadRepoFromError(result)
+    badRepo shouldBe "@@some_workspace_repo"
+  }
+
+  @Test
+  fun `should ignore non retryable repo argument errors`() {
+    val stderr =
+      "ERROR: In repo argument @rules_python+: invalid argument '@rules_python+': invalid user-provided repo name 'rules_python+'"
+    val result = BazelProcessResult(makeOutputCollector(""), makeOutputCollector(stderr), 2)
+
+    val badRepo = ModuleResolver.extractBadRepoFromError(result)
+    badRepo shouldBe null
+  }
+
+  @Test
+  fun `resolveModules should keep successful repos while peeling retryable failures`() {
+    val batchFailure =
+      makeResult(
+        stderr = "ERROR: In repo argument @@bad_repo: no such repo. Type 'bazel help mod' for syntax and help.",
+        exitCode = 2,
+      )
+    val batchSuccess =
+      makeResult(
+        stdout =
+          listOf(
+            httpArchiveStanza("@@good_http", "good_http+", "https://example.com/good_http.tar.gz"),
+            localRepositoryStanza("@@good_local", "good_local+", "good/local"),
+          ).joinToString("\n"),
+      )
+    val resolver = createResolver(batchFailure, batchSuccess)
+
+    val resolved = runBlocking {
+      resolver.resolveModules(listOf("@@good_local", "@@bad_repo", "@@good_http"), bazelInfo())
+    }
+
+    resolved shouldBe mapOf(
+      "@@good_http" to ShowRepoResult.HttpArchiveRepository("good_http+", listOf("https://example.com/good_http.tar.gz")),
+      "@@good_local" to ShowRepoResult.LocalRepository("good_local+", "good/local"),
+      "@@bad_repo" to null,
+    )
+  }
+
+  @Test
+  fun `resolveModules should fall back to individual lookups when batch failure is not retryable`() {
+    val batchFailure = makeResult(stderr = "ERROR: some unrelated bazel error", exitCode = 2)
+    val firstSingleSuccess =
+      makeResult(
+        stdout = httpArchiveStanza("@@good_http", "good_http+", "https://example.com/good_http.tar.gz"),
+      )
+    val secondSingleSuccess =
+      makeResult(
+        stdout = localRepositoryStanza("@@good_local", "good_local+", "good/local"),
+      )
+    val resolver = createResolver(batchFailure, firstSingleSuccess, secondSingleSuccess)
+
+    val resolved = runBlocking {
+      resolver.resolveModules(listOf("@@good_local", "@@good_http"), bazelInfo())
+    }
+
+    resolved shouldBe mapOf(
+      "@@good_http" to ShowRepoResult.HttpArchiveRepository("good_http+", listOf("https://example.com/good_http.tar.gz")),
+      "@@good_local" to ShowRepoResult.LocalRepository("good_local+", "good/local"),
+    )
+  }
+
+  @Test
+  fun `resolveModules should peel multiple retryable failures before succeeding`() {
+    val firstBatchFailure =
+      makeResult(
+        stderr = "ERROR: In repo argument @@bad_a: no such repo. Type 'bazel help mod' for syntax and help.",
+        exitCode = 2,
+      )
+    val secondBatchFailure =
+      makeResult(
+        stderr =
+          "ERROR: In repo argument @@bad_b: Module @@bad_b does not exist in the dependency graph. " +
+            "(Note that unused modules cannot be used here). Type 'bazel help mod' for syntax and help.",
+        exitCode = 2,
+      )
+    val finalSuccess =
+      makeResult(
+        stdout = localRepositoryStanza("@@good_local", "good_local+", "good/local"),
+      )
+    val resolver = createResolver(firstBatchFailure, secondBatchFailure, finalSuccess)
+
+    val resolved = runBlocking {
+      resolver.resolveModules(listOf("@@good_local", "@@bad_b", "@@bad_a"), bazelInfo())
+    }
+
+    resolved shouldBe mapOf(
+      "@@good_local" to ShowRepoResult.LocalRepository("good_local+", "good/local"),
+      "@@bad_a" to null,
+      "@@bad_b" to null,
+    )
+  }
+
+  @Test
+  fun `resolveModules should return null for single retryable failure`() {
+    val singleFailure =
+      makeResult(
+        stderr = "ERROR: In repo argument @@bad_repo: no such repo. Type 'bazel help mod' for syntax and help.",
+        exitCode = 2,
+      )
+    val resolver = createResolver(singleFailure)
+
+    val resolved = runBlocking {
+      resolver.resolveModules(listOf("@@bad_repo"), bazelInfo())
+    }
+
+    resolved shouldBe mapOf("@@bad_repo" to null)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- When WORKSPACE is enabled, `bazel mod show_repo` validates all repo arguments upfront and fails on the first unknown repo without producing any output. Previously this triggered N individual `bazel mod show_repo` calls (one per repo, running serially). In our monorepo this took ~40 minutes, now it takes 3 minutes.
- Now we parse the error to identify the bad repo, remove it from the batch, and retry — reducing calls from O(N) to O(B+1) where B is the number of bad repos.
- Falls back to the existing per-repo resolution for unrecognized errors.

## Environment

- We are running Bazel 7.6.1 with `WORKSPACE` and `MODULE.bazel`. We're doing our best to migrate to Bazel 8.x, but this is slowing us down enough that we wanted to fix it before our migration finishes.

## Workaround for
https://github.com/bazelbuild/bazel/issues/28601


🤖 Generated with [Claude Code](https://claude.com/claude-code)