### PR TITLE
BAZEL-3082 - Extend BepEventHandlerProvider API

### DIFF
--- a/intellij.bazel.connector/resources/intellij.bazel.connector.xml
+++ b/intellij.bazel.connector/resources/intellij.bazel.connector.xml
@@ -16,7 +16,6 @@
     <extensionPoint qualifiedName="org.jetbrains.bazel.bepEventHandlerProvider"
                     interface="org.jetbrains.bazel.server.bep.BepEventHandlerProvider"
                     dynamic="true"
-                    area="IDEA_PROJECT"
     />
   </extensionPoints>
 </idea-plugin>

--- a/intellij.bazel.connector/resources/intellij.bazel.connector.xml
+++ b/intellij.bazel.connector/resources/intellij.bazel.connector.xml
@@ -16,6 +16,7 @@
     <extensionPoint qualifiedName="org.jetbrains.bazel.bepEventHandlerProvider"
                     interface="org.jetbrains.bazel.server.bep.BepEventHandlerProvider"
                     dynamic="true"
+                    area="IDEA_PROJECT"
     />
   </extensionPoints>
 </idea-plugin>

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bep/BepEventHandler.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bep/BepEventHandler.kt
@@ -2,9 +2,12 @@ package org.jetbrains.bazel.server.bep
 
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.bazel.commons.BazelPathsResolver
 import org.jetbrains.bazel.server.diagnostics.DiagnosticsService
 import org.jetbrains.bsp.protocol.BazelTaskEventsHandler
+import org.jetbrains.bsp.protocol.TaskId
 
 /**
  * Allows customizing the behavior of [BepServer.handleEvent].
@@ -20,8 +23,10 @@ interface BepEventHandlerProvider {
 }
 
 class BepEventHandlerContext(
+  val parentId: TaskId,
   val taskEventsHandler: BazelTaskEventsHandler,
   val diagnosticsService: DiagnosticsService,
+  val bazelPathsResolver: BazelPathsResolver,
 )
 
 interface BepEventHandler {

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bep/BepServer.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bep/BepServer.kt
@@ -50,7 +50,12 @@ class BepServer(
   private val customBepEventHandlers: List<BepEventHandler>
 
   init {
-    val bepEventHandlerContext = BepEventHandlerContext(taskEventsHandler, diagnosticsService)
+    val bepEventHandlerContext = BepEventHandlerContext(
+      parentId = parentId,
+      taskEventsHandler = taskEventsHandler,
+      diagnosticsService = diagnosticsService,
+      bazelPathsResolver = bazelPathsResolver
+    )
     customBepEventHandlers = BepEventHandlerProvider.EP_NAME.extensionList.map { it.create(bepEventHandlerContext) }
   }
 
@@ -69,11 +74,6 @@ class BepServer(
 
       LOGGER.trace("Got event ${event}")
 
-      for (customHandler in customBepEventHandlers) {
-        if (customHandler.handleEvent(event)) {
-          return
-        }
-      }
       handleBuildEventStreamProtosEvent(event)
     }
     catch (e: IOException) {
@@ -82,6 +82,11 @@ class BepServer(
   }
 
   fun handleBuildEventStreamProtosEvent(event: BuildEventStreamProtos.BuildEvent) {
+    for (customHandler in customBepEventHandlers) {
+      if (customHandler.handleEvent(event)) {
+        return
+      }
+    }
     processBuildStartedEvent(event)
     processOptions(event)
     processProgressEvent(event)


### PR DESCRIPTION
Set extension point area as IDEA_PROJECT
Extend class BepEventHandlerContext with bazelPathsResolver and parentId
Refactor BepServer#handleEvent to move logic to call BepEventHandler collection within handleBuildEventStreamProtosEvent