### PR TITLE
BAZEL-3091 - Extend HotSwapHook API

### DIFF
--- a/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapActionStatus.kt
+++ b/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapActionStatus.kt
@@ -1,0 +1,8 @@
+package org.jetbrains.bazel.hotswap
+
+enum class BazelHotSwapActionStatus {
+  UNKNOWN,
+  SUCCESS,
+  ERROR,
+  CANCELLED,
+}

--- a/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapManager.kt
+++ b/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapManager.kt
@@ -60,6 +60,11 @@ internal class BazelHotSwapManager(private val project: Project, private val cor
   ) {
     if (sessions.isEmpty()) return
 
+    // Notify hooks that hotswap is starting
+    HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+      hotSwapHook.onHotSwapStarted()
+    }
+
     val tempRoot = Path.of(PathManager.getTempPath())
     val tempDir = createTempDirectory(tempRoot, "class_files_")
     val diff = JarFileManifest.diffJarManifests(oldManifest = oldManifest, newManifest = newManifest)
@@ -73,6 +78,19 @@ internal class BazelHotSwapManager(private val project: Project, private val cor
         .sorted()
         .joinToString("\n"),
     )
+
+    // Report detected files to hooks and service
+    val fileInfoList = diff.perJarModifiedFiles.entrySet().map { entry ->
+      BazelHotSwapFileInfo(
+        jarPath = entry.key,
+        modifiedClasses = entry.value.filter { it.endsWith(".class") }
+          .map { deriveQualifiedClassName(it) }
+      )
+    }
+    HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+      hotSwapHook.onHotSwapFilesDetected(fileInfoList)
+    }
+
     if (hotSwapClassFiles.isNotEmpty()) {
       val progress = withContext(Dispatchers.EDT) {
         HotSwapProgressImpl(project)
@@ -94,17 +112,49 @@ internal class BazelHotSwapManager(private val project: Project, private val cor
             }
 
             listener?.onSuccess(sessions)
+
+            // Report success
+            val successStatus = BazelHotSwapStatus(
+              status = BazelHotSwapActionStatus.SUCCESS,
+              changedClassCount = hotSwapClassFiles.size
+            )
+            runBlockingCancellable {
+              HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+                hotSwapHook.onHotSwapFinished(successStatus)
+              }
+            }
           },
           progress.progressIndicator,
         )
       }
       catch (e: CancellationException) {
         listener?.onCancel(sessions)
+
+        // Report cancellation
+        val cancelledStatus = BazelHotSwapStatus(
+          status = BazelHotSwapActionStatus.CANCELLED,
+          changedClassCount = hotSwapClassFiles.size,
+          cause = e,
+        )
+        HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+          hotSwapHook.onHotSwapFinished(cancelledStatus)
+        }
+
         throw e
       }
       catch (e: Exception) {
         listener?.onFailure(sessions)
         LOG.error("Unable to hotswap", e)
+
+        // Report error
+        val errorStatus = BazelHotSwapStatus(
+          status = BazelHotSwapActionStatus.ERROR,
+          changedClassCount = hotSwapClassFiles.size,
+          cause = e,
+        )
+        HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+          hotSwapHook.onHotSwapFinished(errorStatus)
+        }
       }
       finally {
         progress.finished()
@@ -123,6 +173,15 @@ internal class BazelHotSwapManager(private val project: Project, private val cor
         notification.notify(project)
       }
       listener?.onNothingToReload(sessions)
+
+      // Report success with 0 classes (nothing to reload)
+      val upToDateStatus = BazelHotSwapStatus(
+        status = BazelHotSwapActionStatus.SUCCESS,
+        changedClassCount = 0
+      )
+      HotSwapHook.EP_NAME.extensionList.forEach { hotSwapHook ->
+        hotSwapHook.onHotSwapFinished(upToDateStatus)
+      }
     }
   }
 

--- a/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapStatus.kt
+++ b/java/intellij.bazel.java.common/src/hotswap/BazelHotSwapStatus.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.bazel.hotswap
+
+import java.nio.file.Path
+
+data class BazelHotSwapStatus(
+  val status: BazelHotSwapActionStatus,
+  val changedClassCount: Int,
+  val cause: Exception? = null,
+)
+
+data class BazelHotSwapFileInfo(
+  val jarPath: Path,
+  val modifiedClasses: List<String>,
+)

--- a/java/intellij.bazel.java.common/src/hotswap/HotSwapHook.kt
+++ b/java/intellij.bazel.java.common/src/hotswap/HotSwapHook.kt
@@ -5,7 +5,28 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import org.jetbrains.annotations.ApiStatus
 
 interface HotSwapHook {
-  suspend fun onHotSwap(sessions: List<DebuggerSession>)
+  /**
+   * Legacy method for backward compatibility.
+   * Called when hotswap completes.
+   */
+  suspend fun onHotSwap(sessions: List<DebuggerSession>) {}
+
+  /**
+   * Called when hotswap process starts.
+   */
+  suspend fun onHotSwapStarted() {}
+
+  /**
+   * Called when modified files are detected and ready for hotswap.
+   * @param fileInfo information about modified jar files and their classes
+   */
+  suspend fun onHotSwapFilesDetected(fileInfo: List<BazelHotSwapFileInfo>) {}
+
+  /**
+   * Called when hotswap process finishes with status information.
+   * @param status the result status of the hotswap operation
+   */
+  suspend fun onHotSwapFinished(status: BazelHotSwapStatus) {}
 
   @ApiStatus.Internal
   companion object {


### PR DESCRIPTION
Extended API for HotSwapHook:
- Report start of hotswap
- Report files to be hotswapped
- Report success of hotswap
- Report if hotswap was canceled
- Report if hotswap was terminated due to error