### PR TITLE
BAZEL-3128: Bazel 7 native protobuf support for sync aspects

### DIFF
--- a/intellij.bazel.connector/resources/aspects/rules/protobuf/protobuf_info.bzl.template
+++ b/intellij.bazel.connector/resources/aspects/rules/protobuf/protobuf_info.bzl.template
@@ -1,8 +1,13 @@
 load("//${bspPath}/aspects:utils/utils.bzl", "create_struct")
 load("//${bspPath}/aspects:rules/protobuf/proto_common.bzl", "extract_source_mappings")
 
+#if( $bazel8OrAbove == "true")
+# Bazel 8+: Use the external protobuf providers discovered from the workspace.
 load("@${rulesetName}//bazel/common:proto_info.bzl", "ProtoInfo")
 load("@${rulesetName}//bazel/common:proto_common.bzl", "proto_common")
+#else
+# Bazel < 8 exposes native proto_library support through top-level ProtoInfo and proto_common.
+#end
 
 def has_protoinfo_in_target(target):
     return ProtoInfo in target

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
@@ -78,20 +78,12 @@ class BazelBspAspectsManager(
         rulesetName?.let {
           return@mapNotNull RulesetLanguage(ApparentRulesetName(it), language)
         }
-        if (language.isBundled(externalAutoloads)) {
+        if (language.isBundledFor(bazelRelease, externalAutoloads)) {
           return@mapNotNull RulesetLanguage(null, language)
         }
         null
       }.removeDisabledLanguages()
       .addExternalPythonLanguageIfNeeded(externalRulesetNames)
-  }
-
-  private fun Language.isBundled(externalAutoloads: List<String>): Boolean {
-    if (!isBundled) return false
-    // Bundled in Bazel version < 8
-    if (bazelRelease.major < 8) return true
-    // If a language is autoloaded in Bazel version >= 8, it effectively restores the old "bundled" behavior.
-    return (rulesetNames + autoloadHints).any { it in externalAutoloads }
   }
 
   private fun List<RulesetLanguage>.removeDisabledLanguages(): List<RulesetLanguage> {

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspLanguageExtensionsGenerator.kt
@@ -2,6 +2,7 @@ package org.jetbrains.bazel.server.bsp.managers
 
 import org.apache.velocity.app.VelocityEngine
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.bazel.commons.BazelRelease
 import org.jetbrains.bazel.commons.BzlmodRepoMapping
 import org.jetbrains.bazel.commons.RepoMapping
 import org.jetbrains.bazel.commons.RepoMappingDisabled
@@ -15,6 +16,13 @@ enum class Language(
   private val fileName: String,
   val rulesetNames: List<String>,
   val functions: List<String>,
+  /**
+   * Whether Bazel exposes this language natively before the Bazel 8 external rules migration.
+   *
+   * For Bazel 8 and later, bundled languages are only enabled when this language has explicit
+   * autoload hints and Bazel reports matching external autoloads, which preserves the external-rules
+   * path for languages such as protobuf.
+   */
   val isBundled: Boolean,
   val autoloadHints: List<String> = emptyList(),
   val importsFromRuleSet: Map<String, List<String>> = emptyMap(),
@@ -52,8 +60,20 @@ enum class Language(
   RulesProto("//" + Constants.DOT_BAZELBSP_DIR_NAME + "/aspects:rules/protobuf/rules_proto_info.bzl", listOf("rules_proto"), listOf("extract_rules_proto_info"),
            false, emptyList(), emptyMap(), emptyList(), listOf("https://github.com/bazelbuild/rules_proto")),
   Protobuf("//" + Constants.DOT_BAZELBSP_DIR_NAME + "/aspects:rules/protobuf/protobuf_info.bzl", listOf("protobuf"), listOf("extract_protobuf_info"),
-           false, emptyList(), emptyMap(), emptyList(), listOf("https://github.com/protocolbuffers/protobuf/")),
+           true, emptyList(), emptyMap(), emptyList(), listOf("https://github.com/protocolbuffers/protobuf/")),
   ;
+
+  fun isBundledFor(bazelRelease: BazelRelease, externalAutoloads: List<String>): Boolean {
+    if (!isBundled) return false
+    if (bazelRelease.major < 8) return true
+    // Bazel 8+ only restores the bundled path for languages that opt in via [autoloadHints].
+    // Languages without [autoloadHints] (e.g. Protobuf) must instead be discovered as an
+    // external ruleset by name. Match against both [rulesetNames] and [autoloadHints]
+    // because --incompatible_autoload_externally accepts ruleset names (e.g. "rules_java")
+    // as well as individual symbol names (e.g. "JavaInfo", "PyInfo").
+    if (autoloadHints.isEmpty()) return false
+    return (rulesetNames + autoloadHints).any { it in externalAutoloads }
+  }
 
   fun toLoadStatement(): String =
     this.functions.joinToString(

--- a/pluginTests/test/org/jetbrains/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/server/bsp/managers/BazelBspLanguageExtensionsGeneratorTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bazel.server.bsp.managers
 
 import io.kotest.matchers.shouldBe
+import org.jetbrains.bazel.commons.BazelRelease
 import org.jetbrains.bazel.commons.BzlmodRepoMapping
 import org.jetbrains.bazel.commons.constants.Constants
 import org.jetbrains.bazel.install.EnvironmentCreator
@@ -93,6 +94,12 @@ class BazelBspLanguageExtensionsGeneratorTest {
             TOOLCHAINS=[config_common.toolchain_type("@bazel_tools//tools/jdk:runtime_toolchain_type", mandatory = False),"@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type"]
             REQUIRED_ASPECT_PROVIDERS=[[JavaInfo]]
     """.replace(" ", "").replace("\n", "")
+  private val protobufFileContent =
+    """ load("//.bazelbsp/aspects:rules/protobuf/protobuf_info.bzl","extract_protobuf_info")
+            EXTENSIONS=[extract_protobuf_info]
+            TOOLCHAINS=[]
+            REQUIRED_ASPECT_PROVIDERS=[]
+    """.replace(" ", "").replace("\n", "")
   private val defaultRulesetLanguages =
     listOf(
       RulesetLanguage(null, Language.Java),
@@ -144,6 +151,42 @@ class BazelBspLanguageExtensionsGeneratorTest {
     // then
     val fileContent = getExtensionsFileContent()
     fileContent shouldBe defaultFileContent
+  }
+
+  @Test
+  fun `should create the extensions dot bzl file with native protobuf import`() {
+    // given
+    val ruleLanguages = listOf(RulesetLanguage(null, Language.Protobuf))
+    val bazelBspLanguageExtensionsGenerator =
+      BazelBspLanguageExtensionsGenerator(internalAspectsResolverMock)
+
+    // when
+    bazelBspLanguageExtensionsGenerator.generateLanguageExtensions(ruleLanguages, emptyMap(), emptyRepoMapping, noAutoloads)
+
+    // then
+    val fileContent = getExtensionsFileContent()
+    fileContent shouldBe protobufFileContent
+  }
+
+  @Test
+  fun `should treat protobuf as bundled only before bazel 8`() {
+    Language.Protobuf.isBundledFor(BazelRelease(6, 4), noAutoloads) shouldBe true
+    Language.Protobuf.isBundledFor(BazelRelease(7, 4), noAutoloads) shouldBe true
+    Language.Protobuf.isBundledFor(BazelRelease(8, 0), noAutoloads) shouldBe false
+    Language.Protobuf.isBundledFor(BazelRelease(9, 0), noAutoloads) shouldBe false
+    // Protobuf has no autoloadHints, so it never falls back to bundled even when autoloaded
+    Language.Protobuf.isBundledFor(BazelRelease(8, 0), listOf("protobuf")) shouldBe false
+  }
+
+  @Test
+  fun `should treat java as bundled before bazel 8 and via autoloads on bazel 8`() {
+    Language.Java.isBundledFor(BazelRelease(7, 4), noAutoloads) shouldBe true
+    Language.Java.isBundledFor(BazelRelease(8, 0), noAutoloads) shouldBe false
+    // Ruleset-name autoload (e.g. --incompatible_autoload_externally=+rules_java)
+    Language.Java.isBundledFor(BazelRelease(8, 0), fullAutoloads) shouldBe true
+    // Symbol-name autoload (e.g. --incompatible_autoload_externally=+JavaInfo)
+    Language.Java.isBundledFor(BazelRelease(8, 0), listOf("JavaInfo")) shouldBe true
+    Language.Python.isBundledFor(BazelRelease(8, 0), listOf("PyInfo")) shouldBe true
   }
 
   @Test


### PR DESCRIPTION
For Bazel versions before 8, protobuf is treated as a bundled/native language so proto_library targets are imported even without rules_proto or protobuf declared in MODULE.bazel. Bazel 8+ continues using the existing external ruleset discovery path.

Also adds focused tests for protobuf’s pre-8 bundled behavior and preserves Bazel 8 autoload handling for Java/Python symbol hints.