### PR TITLE
BAZEL-3149: upgrade to toplevel only if remote_download_outputs=minimal

### DIFF
--- a/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/params/BazelFlag.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/params/BazelFlag.kt
@@ -78,6 +78,9 @@ object BazelFlag {
   @JvmStatic
   fun remoteDownloadOutputsTopLevel(): String = arg("remote_download_outputs", "toplevel")
 
+  @JvmStatic
+  fun remoteDownloadRegex(pattern: String): String = arg("remote_download_regex", pattern)
+
   private fun yesNoArg(name: String, enable: Boolean) = arg(name, if (enable) "yes" else "no")
 
   private fun arg(name: String, value: String) = String.format("--%s=%s", name, value)

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
@@ -210,7 +210,6 @@ class BazelBspAspectsManager(
         aspect(aspectsResolver.resolveLabel(aspect)),
         outputGroups(outputGroups),
         keepGoing(),
-        remoteDownloadOutputsTopLevel(),
       )
     val allowManualTargetsSyncFlags = if (workspaceContext.allowManualTargetsSync) listOf(buildManualTests()) else emptyList()
     val syncFlags = workspaceContext.syncFlags
@@ -223,12 +222,21 @@ class BazelBspAspectsManager(
       taskId = taskId,
     )
 
-    val existingBuildTagFilters = emptyBuild.bepOutput.options.lastOrNull { it.startsWith("--build_tag_filters=") }?.removePrefix("--build_tag_filters=")
+    val options = emptyBuild.bepOutput.options
+    val existingBuildTagFilters = options.lastOrNull { it.startsWith("--build_tag_filters=") }?.removePrefix("--build_tag_filters=")
+    // Ensure remote_download_outputs is at least toplevel so that all required output files are downloaded
+    val remoteDownloadOverride =
+      if (options.lastOrNull { it.startsWith("--remote_download_outputs=") } == "--remote_download_outputs=minimal") {
+        listOf(remoteDownloadOutputsTopLevel())
+      } else {
+        emptyList()
+      }
 
     return executeService
       .buildTargetsWithBep(
         targetsSpec = targetsSpec,
-        extraFlags = flagsToUse + listOf("--build_tag_filters=" + existingBuildTagFilters?.let { "$it," }.orEmpty() + "-${Constants.NO_IDE}"),
+        extraFlags = flagsToUse + remoteDownloadOverride +
+          listOf("--build_tag_filters=" + existingBuildTagFilters?.let { "$it," }.orEmpty() + "-${Constants.NO_IDE}"),
         taskId = taskId,
       ).let { BazelBspAspectsManagerResult(it.bepOutput, it.processResult.bazelStatus) }
   }

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/sync/ExecuteService.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/sync/ExecuteService.kt
@@ -188,7 +188,8 @@ class ExecuteService(
     params.environmentVariables?.let { (command as HasEnvironment).environment.putAll(it) }
     params.arguments?.let { (command as HasProgramArguments).programArguments.addAll(it) }
     command.options.add(BazelFlag.buildEventBinaryPathConversion(false))
-    command.options.add(BazelFlag.remoteDownloadOutputsTopLevel())  // We need, e.g., test.xml downloaded when using remote execution
+    // Ensure all test xml, log, and lcov files are downloaded even when remote_download_outputs=minimal is set
+    command.options.add(BazelFlag.remoteDownloadRegex(".*/test\\.(xml|log|lcov)"))
     with(command as HasMultipleTargets) {
       targets.addAll(targetsSpec.values)
       excludedTargets.addAll(targetsSpec.excludedValues)


### PR DESCRIPTION
For Bazel builds that require all, the toplevel setting can break things. By only overriding remote_download_outputs when it was minimal we avoid causing problems in those specific cases.

The execute service specifically only pulls the test xml, log, and lcov outputs, so a simple remote_download_regex works in that case and is less changes.