### PR TITLE
BAZEL-3151: add sibling data to avoid class name collisions due to BAZEL-3117

### DIFF
--- a/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
+++ b/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
@@ -64,7 +64,7 @@ def get_jdeps(ctx, target):
     jdeps = get_raw_jdeps(target)
     materialized_jdeps = []
     for raw_jdeps_file in jdeps:
-        materialized_jdeps_file = ctx.actions.declare_file("materialized_" + raw_jdeps_file.basename)
+        materialized_jdeps_file = ctx.actions.declare_file("materialized_" + raw_jdeps_file.basename, sibling = raw_jdeps_file)
         ctx.actions.run_shell(
             inputs = [raw_jdeps_file],
             outputs = [materialized_jdeps_file],


### PR DESCRIPTION
If a build file isn't fine-grained per package then the current jdeps logic can result in a collision if two or more packages under a BUILD file have a class with the same name.

foo/src/main/java/BUILD (globs **/*.java, lists files individually, etc)
foo/src/main/java/com/foo/AClass.java
foo/src/main/java/com/foo/bar/AClass.java