### PR TITLE
BAZEL-842: Implement fully working partial sync

### DIFF
--- a/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
@@ -13,6 +13,7 @@ import java.nio.file.Path
 @ApiStatus.Internal
 interface BazelTargetPersistenceLayer {
   suspend fun saveAll(project: Project, spec: TargetPersistenceSpec)
+  suspend fun mergePartial(project: Project, spec: TargetPersistenceSpec)
   suspend fun notifyAll(project: Project)
 }
 

--- a/intellij.bazel.core/resources/intellij.bazel.core.xml
+++ b/intellij.bazel.core/resources/intellij.bazel.core.xml
@@ -706,6 +706,10 @@
       class="org.jetbrains.bazel.workspace.fileEvents.BazelFileEventListener"
       topic="com.intellij.openapi.vfs.newvfs.BulkFileListenerBackgroundable"
     />
+    <listener
+      class="org.jetbrains.bazel.projectAware.BuildFileChangeListener"
+      topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"
+    />
   </applicationListeners>
 
 </idea-plugin>

--- a/intellij.bazel.core/src/org/jetbrains/bazel/flow/sync/DirectoriesSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/flow/sync/DirectoriesSyncHook.kt
@@ -9,6 +9,7 @@ import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.flow.exclude.BazelSymlinkExcludeService
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.ProjectSyncHook.ProjectSyncHookEnvironment
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.withSubtask
 import org.jetbrains.bazel.workspacemodel.entities.BazelProjectDirectoriesEntity
 import org.jetbrains.bazel.workspacemodel.entities.BazelProjectDirectoriesEntityBuilder
@@ -18,6 +19,7 @@ import java.nio.file.Path
 
 private class DirectoriesSyncHook : ProjectSyncHook {
   override suspend fun onSync(environment: ProjectSyncHookEnvironment) {
+    if (environment.syncScope is PartialProjectSync) return
     environment.withSubtask("Collect project directories") {
       val directories = environment.server.workspaceDirectories()
       val workspaceContext = environment.server.workspaceContext

--- a/intellij.bazel.core/src/org/jetbrains/bazel/languages/starlark/repomapping/BazelRepoMappingSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/languages/starlark/repomapping/BazelRepoMappingSyncHook.kt
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.bazel.commons.BzlmodRepoMapping
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.ProjectSyncHook.ProjectSyncHookEnvironment
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.withSubtask
 import org.jetbrains.bazel.workspace.BazelRepoMappingService
 import java.nio.file.Path
@@ -34,6 +35,7 @@ fun Project.injectCanonicalRepoNameToApparentName(canonicalRepoNameToApparentNam
 
 internal class BazelRepoMappingSyncHook : ProjectSyncHook {
   override suspend fun onSync(environment: ProjectSyncHookEnvironment) {
+    if (environment.syncScope is PartialProjectSync) return
     environment.withSubtask("Load bazel repo mapping") {
       val bazelRepoMappingService = PersistentBazelRepoMappingService.getInstance(environment.project)
       val bazelRepoMappingResult = environment.server.workspaceBazelRepoMapping(environment.taskId)

--- a/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/BazelProjectAware.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/BazelProjectAware.kt
@@ -16,15 +16,20 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.bazel.commons.constants.Constants
+import org.jetbrains.bazel.config.BazelFeatureFlags
 import org.jetbrains.bazel.config.BazelPluginConstants
 import org.jetbrains.bazel.config.bazelProjectProperties
 import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.coroutines.BazelCoroutineService
+import org.jetbrains.bazel.server.connection.connection
 import org.jetbrains.bazel.settings.bazel.bazelProjectSettings
 import org.jetbrains.bazel.sync.SyncCache
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.SecondPhaseSync
 import org.jetbrains.bazel.sync.status.SyncStatusListener
 import org.jetbrains.bazel.sync.task.ProjectSyncTask
+import org.jetbrains.bsp.protocol.InverseSourcesParams
+import org.jetbrains.bsp.protocol.TaskGroupId
 
 @ApiStatus.Internal
 class BazelProjectAware(private val project: Project) : ExternalSystemProjectAware {
@@ -43,9 +48,32 @@ class BazelProjectAware(private val project: Project) : ExternalSystemProjectAwa
   override fun reloadProject(context: ExternalSystemProjectReloadContext) {
     if (context.isExplicitReload) {
       BazelCoroutineService.getInstance(project).start {
-        ProjectSyncTask(project).sync(syncScope = SecondPhaseSync, buildProject = false)
+        val syncScope = if (BazelFeatureFlags.enablePartialSync) {
+          resolvePartialSyncScope()
+        } else {
+          null
+        }
+        ProjectSyncTask(project).sync(syncScope = syncScope ?: SecondPhaseSync, buildProject = false)
       }
     }
+  }
+
+  private suspend fun resolvePartialSyncScope(): PartialProjectSync? {
+    val changedBuildFiles = ChangedBuildFilesTracker.getInstance(project).consumeChangedFiles()
+    if (changedBuildFiles.isEmpty()) return null
+    if (changedBuildFiles.size > MAX_CHANGED_BUILD_FILES) return null
+
+    val taskId = TaskGroupId("partial-sync-resolve").task("resolve-targets")
+    val affectedTargets = try {
+      project.connection.runWithServer {
+        it.buildTargetInverseSources(InverseSourcesParams(taskId, changedBuildFiles.toList()))
+      }.targets.values.flatten().distinct()
+    } catch (_: Exception) {
+      return null
+    }
+
+    if (affectedTargets.isEmpty() || affectedTargets.size > MAX_PARTIAL_SYNC_TARGETS) return null
+    return PartialProjectSync(targetsToSync = affectedTargets)
   }
 
   override fun subscribe(listener: ExternalSystemProjectListener, parentDisposable: Disposable) {
@@ -119,3 +147,6 @@ private val GLOBAL_CONFIG_FILES: Array<String> = Constants.WORKSPACE_FILE_NAMES 
 
 // Bazel config files to look for in all project directories
 private val LOCAL_CONFIG_FILES: Set<String> = Constants.BUILD_FILE_NAMES.toSet()
+
+private const val MAX_PARTIAL_SYNC_TARGETS = 50
+private const val MAX_CHANGED_BUILD_FILES = 20

--- a/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/BuildFileChangeListener.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/BuildFileChangeListener.kt
@@ -1,0 +1,40 @@
+package org.jetbrains.bazel.projectAware
+
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.bazel.commons.constants.Constants
+import org.jetbrains.bazel.config.isBazelProject
+
+/**
+ * Lightweight listener that records BUILD file changes so that [BazelProjectAware.reloadProject]
+ * can determine which targets are affected and trigger a partial sync instead of a full sync.
+ */
+@ApiStatus.Internal
+class BuildFileChangeListener : BulkFileListener {
+  override fun after(events: MutableList<out VFileEvent>) {
+    val buildFileEvents = events.filter { event ->
+      val fileName = when (event) {
+        is VFileContentChangeEvent -> event.file.name
+        is VFileCreateEvent -> event.childName
+        else -> event.file?.name
+      }
+      fileName != null && fileName in BUILD_FILE_NAMES
+    }
+    if (buildFileEvents.isEmpty()) return
+
+    val projects = ProjectManager.getInstance().openProjects.filter { it.isBazelProject }
+    for (project in projects) {
+      val tracker = ChangedBuildFilesTracker.getInstance(project)
+      for (event in buildFileEvents) {
+        val path = event.file?.toNioPath() ?: continue
+        tracker.addChangedFile(path)
+      }
+    }
+  }
+}
+
+private val BUILD_FILE_NAMES: Set<String> = Constants.BUILD_FILE_NAMES.toSet()

--- a/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/ChangedBuildFilesTracker.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/projectAware/ChangedBuildFilesTracker.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.bazel.projectAware
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.ApiStatus
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Tracks BUILD file changes between syncs. When the user clicks "Load Bazel Changes",
+ * this service provides the set of changed BUILD files so we can resolve affected targets
+ * and perform a partial sync instead of a full sync.
+ */
+@ApiStatus.Internal
+@Service(Service.Level.PROJECT)
+class ChangedBuildFilesTracker {
+  private val changedBuildFiles = ConcurrentHashMap.newKeySet<Path>()
+
+  fun addChangedFile(path: Path) {
+    changedBuildFiles.add(path)
+  }
+
+  fun consumeChangedFiles(): Set<Path> {
+    val result = changedBuildFiles.toSet()
+    changedBuildFiles.clear()
+    return result
+  }
+
+  companion object {
+    fun getInstance(project: Project): ChangedBuildFilesTracker = project.service()
+  }
+}

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
@@ -19,6 +19,7 @@ import org.jetbrains.bazel.run.state.HasBazelParams
 import org.jetbrains.bazel.run.state.HasEnv
 import org.jetbrains.bazel.run.state.HasProgramArguments
 import org.jetbrains.bazel.sync.ProjectSyncHook
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.withSubtask
 import java.nio.file.Path
 
@@ -28,6 +29,7 @@ internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
   private val log = logger<ImportRunConfigurationsSyncHook>()
 
   override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) {
+    if (environment.syncScope is PartialProjectSync) return
     environment.withSubtask("Import run configurations") {
       val project = environment.project
       val workspaceContext = environment.server.workspaceContext

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/action/ResyncTargetAction.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/action/ResyncTargetAction.kt
@@ -8,7 +8,6 @@ import org.jetbrains.bazel.config.BazelFeatureFlags
 import org.jetbrains.bazel.config.BazelPluginBundle
 import org.jetbrains.bazel.config.isBazelProject
 import org.jetbrains.bazel.label.Label
-import org.jetbrains.bazel.settings.bazel.bazelJVMProjectSettings
 import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.status.isSyncInProgress
 import org.jetbrains.bazel.sync.task.ProjectSyncTask
@@ -21,9 +20,7 @@ internal class ResyncTargetAction private constructor(private val targetId: Labe
     }
 
     override fun update(project: Project, e: AnActionEvent) {
-      // for now we dont support jps modules (TODO: https://youtrack.jetbrains.com/issue/BAZEL-1238)
-      val isJpsDisabled = !project.bazelJVMProjectSettings.enableBuildWithJps
-      e.presentation.isVisible = BazelFeatureFlags.enablePartialSync && project.isBazelProject && isJpsDisabled
+      e.presentation.isVisible = BazelFeatureFlags.enablePartialSync && project.isBazelProject
       e.presentation.isEnabled = !project.isSyncInProgress()
     }
 

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/ProjectModelApplicatonTask.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/ProjectModelApplicatonTask.kt
@@ -9,6 +9,7 @@ import com.intellij.platform.workspace.storage.EntitySource
 import com.intellij.platform.workspace.storage.MutableEntityStorage
 import com.intellij.workspaceModel.ide.impl.WorkspaceModelImpl
 import org.jetbrains.bazel.config.BazelPluginBundle
+import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
 import org.jetbrains.bazel.performance.bspTracer
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.progress.withSubtask
@@ -16,6 +17,7 @@ import org.jetbrains.bazel.sync.scope.FullProjectSync
 import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.ProjectSyncScope
 import org.jetbrains.bazel.workspacemodel.entities.BazelEntitySource
+import org.jetbrains.bazel.workspacemodel.entities.BazelModuleEntitySource
 import org.jetbrains.bsp.protocol.TaskId
 
 internal class ProjectModelApplicatonTask(
@@ -32,7 +34,13 @@ internal class ProjectModelApplicatonTask(
     val sourceFilter: (EntitySource) -> Boolean =
       when (scope) {
         is FullProjectSync -> { entitySource -> entitySource is BazelEntitySource }
-        is PartialProjectSync -> error("not supported")
+        is PartialProjectSync -> {
+          val moduleNames = scope.targetsToSync.map { it.formatAsModuleName(project) }.toSet()
+          val filter: (EntitySource) -> Boolean = { entitySource ->
+            entitySource is BazelModuleEntitySource && entitySource.moduleName in moduleNames
+          }
+          filter
+        }
       }
 
     fun MutableEntityStorage.replaceBySource() {

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/legacy/WorkspaceModuleProjectSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/legacy/WorkspaceModuleProjectSyncHook.kt
@@ -16,6 +16,7 @@ import com.intellij.platform.workspace.jps.entities.SourceRootTypeId
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.sync.ProjectSyncHook
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.workspacemodel.entities.BazelModuleEntitySource
 
 internal val GENERIC_SOURCE_ROOT_TYPE_ID = SourceRootTypeId("generic-source")
@@ -29,6 +30,7 @@ class WorkspaceModuleProjectSyncHook : ProjectSyncHook {
   override fun isEnabled(project: Project): Boolean = true
 
   override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) {
+    if (environment.syncScope is PartialProjectSync) return
     val project = environment.project
     if (!EnableWorkspaceModuleSyncHookExtension.EP.extensionList.any { it.isEnabled(environment) }) return
     val moduleEntitySource = BazelModuleEntitySource(WORKSPACE_MODULE_NAME)

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -43,6 +43,7 @@ import org.jetbrains.bazel.sync.projectPostSyncHooks
 import org.jetbrains.bazel.sync.projectPreSyncHooks
 import org.jetbrains.bazel.sync.projectStructure.ProjectModelApplicatonTask
 import org.jetbrains.bazel.sync.projectSyncHooks
+import org.jetbrains.bazel.sync.scope.FullProjectSync
 import org.jetbrains.bazel.sync.scope.ProjectSyncScope
 import org.jetbrains.bazel.sync.status.SyncAlreadyInProgressException
 import org.jetbrains.bazel.sync.status.SyncStatusService
@@ -86,7 +87,7 @@ class ProjectSyncTask(private val project: Project) {
             BazelTaskEventsService.getInstance(project).saveListener(taskId.taskGroupId, taskListener)
 
             val syncJob = BazelCoroutineService.getInstance(project).startAsync(lazy = true) {
-              preSync()
+              preSync(syncScope)
               doSync(taskId, syncScope, buildProject)
             }
 
@@ -160,10 +161,12 @@ class ProjectSyncTask(private val project: Project) {
     }
   }
 
-  private suspend fun preSync() {
+  private suspend fun preSync(syncScope: ProjectSyncScope) {
     log.debug("Running pre sync tasks")
     saveAllFiles()
-    clearSyntheticTargets()
+    if (syncScope is FullProjectSync) {
+      clearSyntheticTargets()
+    }
   }
 
   private suspend fun clearSyntheticTargets() {
@@ -279,8 +282,10 @@ class ProjectSyncTask(private val project: Project) {
             subtaskId = taskId.subTask("base-project-sync-subtask-id"),
             message = BazelPluginBundle.message("console.task.base.sync"),
           ) { subtaskId ->
-            // force full re-sync
-            resolver.invalidateCachedState()
+            if (syncScope is FullProjectSync) {
+              // force full re-sync
+              resolver.invalidateCachedState()
+            }
             resolver.getOrFetchSyncedProject(build = buildProject, taskId = subtaskId).also {
               it.targets.values.filter { it.tagsList.any { it.equals(Constants.NO_IDE) }}.let {
                 if (!it.isEmpty()) {

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetUtils.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetUtils.kt
@@ -159,6 +159,35 @@ class TargetUtils(private val project: Project, private val coroutineScope: Coro
     }
   }
 
+  fun mergeTargets(
+    targets: List<RawBuildTarget>,
+    fileToTarget: Map<Path, List<Label>>,
+    libraryItems: List<LibraryItem>,
+  ) {
+    ThreadingAssertions.assertBackgroundThread()
+
+    val executableTargets =
+      calculateExecutableTargets(
+        targets = fileToTarget.flatMap { it.value }.distinct(),
+        targetDirectDependentsGraph = calculateDirectDependentsGraph(targets),
+        labelToTargetInfo = targets.associateByTo(HashMap(targets.size)) { it.id },
+      )
+
+    db.mergePartial(
+      fileToTarget = fileToTarget,
+      executableTargets = executableTargets,
+      libraryItems = libraryItems,
+      targets = targets,
+    )
+
+    notifyTargetListUpdated()
+
+    coroutineScope.launch(Dispatchers.IO + NonCancellable) {
+      db.save()
+      lastSaved = nowAsDuration()
+    }
+  }
+
   private fun calculateDirectDependentsGraph(targets: List<RawBuildTarget>): Map<Label, Set<Label>> {
     val targetIdToDirectDependentIds = hashMapOf<Label, MutableSet<Label>>()
     for (targetInfo in targets) {

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetsCacheStorage.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetsCacheStorage.kt
@@ -190,6 +190,44 @@ class TargetsCacheStorage(
     }
   }
 
+  fun mergePartial(
+    fileToTarget: Map<Path, List<Label>>,
+    executableTargets: Map<ResolvedLabel, List<Label>>,
+    libraryItems: List<LibraryItem>,
+    targets: List<BuildTarget>,
+  ) {
+    val hashStream = Hashing.xxh3_64()
+      .hashStream()
+
+    for ((file, targets) in fileToTarget) {
+      this.fileToTargets.put(fileToKey(file), targets.map { hashStream.computeLabelHash(it as ResolvedLabel) })
+    }
+
+    for ((label, targets) in executableTargets) {
+      this.targetToExecutableTargets.put(hashStream.computeLabelHash(label), targets.map { hashStream.computeLabelHash(it as ResolvedLabel) })
+    }
+
+    for (library in libraryItems) {
+      this.libraryIdToTarget.put(stringToHashId(library.id.formatAsModuleName(project)), library.id)
+    }
+
+    for (target in targets) {
+      val label = target.id as ResolvedLabel
+      val labelHash = hashStream.computeLabelHash(label)
+      this.labelToTargetInfo.put(
+        labelHash,
+        PartialBuildTarget(
+          id = target.id,
+          kind = target.kind,
+          baseDirectory = target.baseDirectory,
+          data = target.data,
+          isManual = target.isManual,
+        ),
+      )
+      this.moduleIdToTarget.put(stringToHashId(label.formatAsModuleName(project)), labelHash)
+    }
+  }
+
   fun getTotalFileCount(): Int = fileToTargets.size
 
   fun close() {

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
@@ -17,6 +17,17 @@ internal class TargetUtilsTargetPersistanceLayer : BazelTargetPersistenceLayer {
     )
   }
 
+  override suspend fun mergePartial(
+    project: Project,
+    spec: TargetPersistenceSpec,
+  ) {
+    project.targetUtils.mergeTargets(
+      targets = spec.targets,
+      fileToTarget = spec.file2Target,
+      libraryItems = spec.libraryItems,
+    )
+  }
+
   override suspend fun notifyAll(project: Project) {
     project.targetUtils.notifyTargetListUpdated()
   }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/workspace/indexAdditionalFiles/IndexAdditionalFilesSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/workspace/indexAdditionalFiles/IndexAdditionalFilesSyncHook.kt
@@ -18,6 +18,7 @@ import org.jetbrains.bazel.commons.constants.Constants
 import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.settings.bazel.bazelProjectSettings
 import org.jetbrains.bazel.sync.ProjectSyncHook
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.withSubtask
 import org.jetbrains.bazel.workspace.bazelProjectDirectoriesEntity
 import org.jetbrains.bazel.workspacemodel.entities.BazelProjectDirectoriesEntity
@@ -35,7 +36,8 @@ private val INDEX_ADDITIONAL_FILES_DEFAULT =
  *    so that "Go to file by name" is quicker, see https://youtrack.jetbrains.com/issue/IJPL-207088
  */
 private class IndexAdditionalFilesSyncHook : ProjectSyncHook {
-  override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) =
+  override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) {
+    if (environment.syncScope is PartialProjectSync) return
     environment.withSubtask("Collect additional files to index") {
       val project = environment.project
 
@@ -58,6 +60,7 @@ private class IndexAdditionalFilesSyncHook : ProjectSyncHook {
         this.indexAdditionalFiles += indexAdditionalFiles
       }
     }
+  }
 
   private fun indexAdditionalFilesByName(
     environment: ProjectSyncHook.ProjectSyncHookEnvironment,

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/PathSyncHook.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/PathSyncHook.kt
@@ -5,10 +5,12 @@ import kotlinx.coroutines.coroutineScope
 import org.jetbrains.bazel.config.workspaceName
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.environment.BazelProjectContextService
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.withSubtask
 
 internal class PathSyncHook : ProjectSyncHook {
-  override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) =
+  override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) {
+      if (environment.syncScope is PartialProjectSync) return
       coroutineScope {
           environment.withSubtask("Collect bazel workspace info") {
               val projectCtxService = environment.project.serviceAsync<BazelProjectContextService>()
@@ -19,4 +21,5 @@ internal class PathSyncHook : ProjectSyncHook {
               environment.project.workspaceName = bazelWorkspaceResult.workspaceName
           }
       }
+  }
 }

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
@@ -3,6 +3,7 @@ package org.jetbrains.bazel.sync.hooks
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.environment.TargetPersistenceSpec
 import org.jetbrains.bazel.sync.environment.projectCtx
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 
 // TODO: rename
 internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
@@ -15,7 +16,11 @@ internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
         targets = workspace.targets,
         file2Target = workspace.fileToTarget,
     )
-    targetPersistanceLayer.saveAll(project, spec)
+    if (environment.syncScope is PartialProjectSync) {
+      targetPersistanceLayer.mergePartial(project, spec)
+    } else {
+      targetPersistanceLayer.saveAll(project, spec)
+    }
     targetPersistanceLayer.notifyAll(project)
   }
 }

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/scope/ProjectSyncScope.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/scope/ProjectSyncScope.kt
@@ -8,7 +8,6 @@ import org.jetbrains.bazel.label.Label
  * - full project syncs (all targets are re-synced)
  * - partial syncs (only a subset of targets is re-synced).
  */
-// TODO: remove completely on monolithic sync due to being unused and broken
 @ApiStatus.Internal
 sealed interface ProjectSyncScope
 

--- a/pluginTests/test/org/jetbrains/bazel/projectAware/ChangedBuildFilesTrackerTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/projectAware/ChangedBuildFilesTrackerTest.kt
@@ -1,0 +1,48 @@
+package org.jetbrains.bazel.projectAware
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.jetbrains.bazel.workspace.model.test.framework.MockProjectBaseTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+
+@DisplayName("ChangedBuildFilesTracker tests")
+class ChangedBuildFilesTrackerTest : MockProjectBaseTest() {
+
+  @Test
+  fun `should track changed files`() {
+    val tracker = ChangedBuildFilesTracker.getInstance(project)
+    val path1 = Path("/workspace/foo/BUILD")
+    val path2 = Path("/workspace/bar/BUILD.bazel")
+
+    tracker.addChangedFile(path1)
+    tracker.addChangedFile(path2)
+
+    val result = tracker.consumeChangedFiles()
+    result.shouldContainExactlyInAnyOrder(path1, path2)
+  }
+
+  @Test
+  fun `consumeChangedFiles should clear the tracked files`() {
+    val tracker = ChangedBuildFilesTracker.getInstance(project)
+    tracker.addChangedFile(Path("/workspace/foo/BUILD"))
+
+    tracker.consumeChangedFiles()
+    val secondResult = tracker.consumeChangedFiles()
+    secondResult.shouldBeEmpty()
+  }
+
+  @Test
+  fun `should deduplicate same file added multiple times`() {
+    val tracker = ChangedBuildFilesTracker.getInstance(project)
+    val path = Path("/workspace/foo/BUILD")
+
+    tracker.addChangedFile(path)
+    tracker.addChangedFile(path)
+
+    val result = tracker.consumeChangedFiles()
+    result.size shouldBe 1
+  }
+}

--- a/pluginTests/test/org/jetbrains/bazel/sync/task/PartialSyncTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/sync/task/PartialSyncTest.kt
@@ -1,0 +1,99 @@
+package org.jetbrains.bazel.sync.task
+
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.platform.workspace.storage.EntitySource
+import com.intellij.testFramework.registerOrReplaceServiceInstance
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.bazel.config.rootDir
+import org.jetbrains.bazel.impl.flow.sync.TestProjectSyncHook
+import org.jetbrains.bazel.label.Label
+import org.jetbrains.bazel.server.connection.BazelServerService
+import org.jetbrains.bazel.sync.ProjectSyncHook
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
+import org.jetbrains.bazel.sync.scope.SecondPhaseSync
+import org.jetbrains.bazel.sync.workspace.BazelResolvedWorkspace
+import org.jetbrains.bazel.sync.workspace.BazelWorkspaceResolveService
+import org.jetbrains.bazel.workspace.model.test.framework.BazelWorkspaceResolveServiceMock
+import org.jetbrains.bazel.workspace.model.test.framework.BuildServerMock
+import org.jetbrains.bazel.workspace.model.test.framework.MockBuildServerService
+import org.jetbrains.bazel.workspace.model.test.framework.MockProjectBaseTest
+import org.jetbrains.bazel.workspacemodel.entities.BazelEntitySource
+import org.jetbrains.bazel.workspacemodel.entities.BazelModuleEntitySource
+import org.jetbrains.bazel.workspacemodel.entities.BazelProjectEntitySource
+import org.jetbrains.bsp.protocol.WorkspaceBuildTargetsResult
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+
+@DisplayName("Partial sync tests")
+class PartialSyncTest : MockProjectBaseTest() {
+
+  @BeforeEach
+  fun beforeAll() {
+    project.rootDir = VirtualFileManager.getInstance().findFileByNioPath(Path(project.basePath!!))!!
+  }
+
+  @Test
+  fun `partial sync should call enabled sync hooks`() {
+    // given
+    project.registerOrReplaceServiceInstance(BazelServerService::class.java, MockBuildServerService(BuildServerMock()), disposable)
+    project.registerOrReplaceServiceInstance(
+      BazelWorkspaceResolveService::class.java,
+      BazelWorkspaceResolveServiceMock(
+        resolvedWorkspace = BazelResolvedWorkspace(targets = listOf()),
+        bazelProject = WorkspaceBuildTargetsResult(mapOf(), setOf()),
+      ),
+      disposable,
+    )
+
+    val syncHook = TestProjectSyncHook()
+    ProjectSyncHook.ep.registerExtension(syncHook)
+
+    val target = Label.parse("//foo/bar:baz")
+    val scope = PartialProjectSync(targetsToSync = listOf(target))
+
+    // when
+    runBlocking {
+      ProjectSyncTask(project).sync(syncScope = scope, buildProject = false)
+    }
+
+    // then
+    syncHook.wasCalled shouldBe true
+  }
+
+  @Test
+  fun `partial sync source filter should match only targeted module entity sources`() {
+    val moduleNameA = "foo.bar.baz"
+    val moduleNameB = "other.module"
+    val targetedModuleNames = setOf(moduleNameA)
+
+    val sourceA = BazelModuleEntitySource(moduleNameA)
+    val sourceB = BazelModuleEntitySource(moduleNameB)
+    val projectSource = BazelProjectEntitySource
+
+    val filter: (EntitySource) -> Boolean = { entitySource ->
+      entitySource is BazelModuleEntitySource && entitySource.moduleName in targetedModuleNames
+    }
+
+    filter(sourceA) shouldBe true
+    filter(sourceB) shouldBe false
+    filter(projectSource) shouldBe false
+  }
+
+  @Test
+  fun `full sync source filter should match all BazelEntitySource instances`() {
+    val sourceA = BazelModuleEntitySource("module.a")
+    val sourceB = BazelModuleEntitySource("module.b")
+    val projectSource = BazelProjectEntitySource
+
+    val filter: (EntitySource) -> Boolean = { entitySource ->
+      entitySource is BazelEntitySource
+    }
+
+    filter(sourceA) shouldBe true
+    filter(sourceB) shouldBe true
+    filter(projectSource) shouldBe true
+  }
+}


### PR DESCRIPTION
## Summary

Implements YouTrack [BAZEL-842 / Fully working partial sync](https://youtrack.jetbrains.com/issue/BAZEL-842) and its open sub-tickets (BAZEL-843 change detection, BAZEL-844 affected target resolution). BAZEL-845 (BSP `SpecificTargets` selector) was already merged.

Today, every re-sync replaces all Bazel entities via `replaceBySource()`, even when a single BUILD file changed. `PartialProjectSync` was defined but `ProjectModelApplicatonTask` explicitly threw `error(\"not supported\")`. This PR makes partial sync end-to-end functional.

## What changes

### Core fix
- `ProjectModelApplicatonTask`: replace the hard error with a source filter scoped to `BazelModuleEntitySource(moduleName)` for exactly the targets being re-synced. Other modules and project-level entities (`BazelProjectEntitySource`) are preserved untouched.

### Sync orchestration (`ProjectSyncTask`)
- Skip `resolver.invalidateCachedState()` and `clearSyntheticTargets()` during partial sync — both assume full-scope semantics and would discard untouched cached state.

### Hook guards
- Project-scoped hooks early-return for `PartialProjectSync`: `DirectoriesSyncHook`, `IndexAdditionalFilesSyncHook`, `PathSyncHook`, `BazelRepoMappingSyncHook`, `WorkspaceModuleProjectSyncHook`, `ImportRunConfigurationsSyncHook`.
- `TargetPersistenceLayerSyncHook` routes through the new `mergePartial()` for partial sync, so the on-disk MVStore target cache is updated rather than reset.

### Persistence layer
- New `BazelTargetPersistenceLayer.mergePartial(project, spec)`.
- `TargetUtils.mergeTargets` + `TargetsCacheStorage.mergePartial` update `fileToTargets`, `targetToExecutableTargets`, `libraryIdToTarget`, `labelToTargetInfo`, and `moduleIdToTarget` per-key without `.clear()`-ing the maps.

### Auto-trigger
- New `BuildFileChangeListener` (application-level `BulkFileListener`) records BUILD/BUILD.bazel changes into a per-project `ChangedBuildFilesTracker`.
- `BazelProjectAware.reloadProject` consumes the tracker, resolves affected targets via `buildTargetInverseSources`, and invokes `PartialProjectSync` when 1..`MAX_PARTIAL_SYNC_TARGETS` (=50) targets are affected from ≤ `MAX_CHANGED_BUILD_FILES` (=20) BUILD files. Falls back to `SecondPhaseSync` otherwise.
- Gated on existing `BazelFeatureFlags.enablePartialSync` (off by default).

### Misc
- `ResyncTargetAction`: drop the JPS-disabled restriction now that partial sync handles the workspace model correctly.
- Remove the *unused and broken* TODO from `ProjectSyncScope`.

## Tests
- `PartialSyncTest`: sync hook invocation + source-filter semantics for partial vs. full sync.
- `ChangedBuildFilesTrackerTest`: tracking, consume-clears, and deduplication.

Per `docs/dev/development_setup.md`, plugin tests cannot be compiled locally from source. Relying on CI to exercise these.

## Behavior
| Scenario | Before | After |
|---|---|---|
| Right-click target → Resync Target | Throws `\"not supported\"` (and gated to non-JPS only) | Re-syncs only that target's module entities |
| Save a BUILD file → click \"Load Bazel Changes\" | Full re-sync of every target | Partial re-sync of just affected targets (when ≤50) |
| Modify a non-BUILD project setting (.bazelrc, MODULE.bazel, project view) | Full re-sync | Full re-sync (unchanged) |
| `BazelFeatureFlags.enablePartialSync` off | Always full re-sync | Always full re-sync (unchanged) |

## Risk mitigation
- **Off by default.** All partial-sync code paths are gated on `bsp.enable.partial.sync`. Toggling the flag off restores the previous behavior exactly.
- **Conservative thresholds.** Auto-trigger falls back to full sync when too many targets are affected.
- **Full-sync path unchanged.** The `is FullProjectSync ->` branch in every guarded location is byte-identical to before.

## Test plan
- [ ] CI runs the new `PartialSyncTest` and `ChangedBuildFilesTrackerTest`
- [ ] CI runs the existing `ProjectSyncTaskTest` (regression check on the orchestration changes)
- [ ] Manual smoke: enable `bsp.enable.partial.sync` in Registry, open a multi-target Bazel project, right-click a target → Resync Target, confirm only that target's modules update and unrelated modules remain green
- [ ] Manual smoke: save a BUILD file, click \"Load Bazel Changes\", confirm partial sync runs (visible in sync console) and other modules don't get rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)