### PR TITLE
Support target-scoped partial sync

### DIFF
--- a/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
@@ -3,7 +3,6 @@ package org.jetbrains.bazel.sync.environment
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.bazel.label.Label
-import org.jetbrains.bsp.protocol.LibraryItem
 import org.jetbrains.bsp.protocol.RawBuildTarget
 import java.nio.file.Path
 
@@ -13,6 +12,7 @@ import java.nio.file.Path
 @ApiStatus.Internal
 interface BazelTargetPersistenceLayer {
   suspend fun saveAll(project: Project, spec: TargetPersistenceSpec)
+  suspend fun mergePartial(project: Project, targetsToReplace: Collection<Label>, spec: TargetPersistenceSpec)
   suspend fun notifyAll(project: Project)
 }
 

--- a/intellij.bazel.commons/src/org/jetbrains/bsp/protocol/BuildTarget.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bsp/protocol/BuildTarget.kt
@@ -15,8 +15,10 @@ interface ExecutableTarget {
 interface BuildTarget : ExecutableTarget {
   override val id: Label
   override val kind: TargetKind
+  val dependencies: List<DependencyLabel>
   val baseDirectory: Path
   val data: List<BuildTargetData>
+  val generatorName: String?
 
   /**
    * From Bazel doc (https://bazel.build/reference/be/common-definitions)
@@ -34,13 +36,13 @@ interface BuildTarget : ExecutableTarget {
 @ApiStatus.Internal
 data class RawBuildTarget(
   override val id: Label,
-  val dependencies: List<DependencyLabel>,
+  override val dependencies: List<DependencyLabel>,
   override val kind: TargetKind,
   val sources: List<SourceItem>,
   val resources: List<Path>,
   override val baseDirectory: Path,
   override val data: List<BuildTargetData> = emptyList(),
-  val generatorName: String? = null,
+  override val generatorName: String? = null,
   override val isManual: Boolean = false,
   override val isWorkspace: Boolean = true,
 ) : BuildTarget
@@ -48,9 +50,11 @@ data class RawBuildTarget(
 @ApiStatus.Internal
 data class PartialBuildTarget(
   override val id: Label,
+  override val dependencies: List<DependencyLabel> = emptyList(),
   override val kind: TargetKind,
   override val baseDirectory: Path,
   override val data: List<BuildTargetData> = emptyList(),
+  override val generatorName: String? = null,
   override val isManual: Boolean,
   override val isWorkspace: Boolean
 ) : BuildTarget

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/ProjectModelApplicatonTask.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/projectStructure/ProjectModelApplicatonTask.kt
@@ -5,10 +5,15 @@ import com.intellij.openapi.project.Project
 import com.intellij.platform.backend.workspace.WorkspaceModel
 import com.intellij.platform.diagnostic.telemetry.helpers.use
 import com.intellij.platform.diagnostic.telemetry.helpers.useWithScope
-import com.intellij.platform.workspace.storage.EntitySource
+import com.intellij.platform.workspace.jps.entities.LibraryEntity
+import com.intellij.platform.workspace.jps.entities.ModuleEntity
 import com.intellij.platform.workspace.storage.MutableEntityStorage
+import com.intellij.platform.workspace.storage.WorkspaceEntity
+import com.intellij.platform.workspace.storage.entities
 import com.intellij.workspaceModel.ide.impl.WorkspaceModelImpl
 import org.jetbrains.bazel.config.BazelPluginBundle
+import org.jetbrains.bazel.label.Label
+import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
 import org.jetbrains.bazel.performance.bspTracer
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.progress.withSubtask
@@ -16,6 +21,12 @@ import org.jetbrains.bazel.sync.scope.FullProjectSync
 import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.ProjectSyncScope
 import org.jetbrains.bazel.workspacemodel.entities.BazelEntitySource
+import org.jetbrains.bazel.workspacemodel.entities.BazelModuleEntitySource
+import org.jetbrains.bazel.workspacemodel.entities.BazelProjectDirectoriesEntity
+import org.jetbrains.bazel.workspacemodel.entities.CompiledSourceCodeInsideJarExcludeEntity
+import org.jetbrains.bazel.workspacemodel.entities.LibraryCompiledSourceCodeInsideJarExcludeEntity
+import org.jetbrains.bazel.workspacemodel.entities.bazelLibraryExtension
+import org.jetbrains.bazel.workspacemodel.entities.bazelModuleExtension
 import org.jetbrains.bsp.protocol.TaskId
 
 internal class ProjectModelApplicatonTask(
@@ -23,23 +34,25 @@ internal class ProjectModelApplicatonTask(
   private val scope: ProjectSyncScope,
   private val taskId: TaskId,
   private val postActions: List<suspend () -> Unit>,
+  private val targetsToReplace: Set<Label> = emptySet(),
 ) {
   companion object {
     private const val MAX_REPLACE_WSM_ATTEMPTS = 3
   }
 
   suspend fun apply(storage: MutableEntityStorage) {
-    val sourceFilter: (EntitySource) -> Boolean =
-      when (scope) {
-        is FullProjectSync -> { entitySource -> entitySource is BazelEntitySource }
-        is PartialProjectSync -> error("not supported")
-      }
-
-    fun MutableEntityStorage.replaceBySource() {
+    fun MutableEntityStorage.replaceAllBazelEntities() {
       replaceBySource(
-        sourceFilter = sourceFilter,
+        sourceFilter = { entitySource -> entitySource is BazelEntitySource },
         replaceWith = storage,
       )
+    }
+
+    fun MutableEntityStorage.replacePartialBazelEntities() {
+      val targetModuleNames = targetsToReplace.map { it.formatAsModuleName(project) }.toSet()
+      removeTargetEntities(targetsToReplace, targetModuleNames)
+      storage.keepOnlyTargetEntities(targetsToReplace, targetModuleNames)
+      applyChangesFrom(storage)
     }
 
     project.syncConsole.withSubtask(
@@ -53,7 +66,10 @@ internal class ProjectModelApplicatonTask(
           MAX_REPLACE_WSM_ATTEMPTS,
         ) { builder ->
           bspTracer.spanBuilder("replaceprojectmodel.in.apply.on.workspace.model.ms").use {
-            builder.replaceBySource()
+            when (scope) {
+              is FullProjectSync -> builder.replaceAllBazelEntities()
+              is PartialProjectSync -> builder.replacePartialBazelEntities()
+            }
           }
         }
       }
@@ -61,4 +77,39 @@ internal class ProjectModelApplicatonTask(
 
     postActions.forEach { it() }
   }
+
+  private fun MutableEntityStorage.removeTargetEntities(targetLabels: Set<Label>, targetModuleNames: Set<String>) {
+    entities(ModuleEntity::class.java)
+      .filter { it.isTargetModule(targetLabels, targetModuleNames) }
+      .toList()
+      .forEach { removeEntity(it) }
+
+    entities(LibraryEntity::class.java)
+      .filter { it.isTargetLibrary(targetLabels, targetModuleNames) }
+      .toList()
+      .forEach { removeEntity(it) }
+  }
+
+  private fun MutableEntityStorage.keepOnlyTargetEntities(targetLabels: Set<Label>, targetModuleNames: Set<String>) {
+    entities(ModuleEntity::class.java)
+      .filterNot { it.isTargetModule(targetLabels, targetModuleNames) }
+      .toList()
+      .forEach { removeEntity(it) }
+
+    removeEntities<BazelProjectDirectoriesEntity>()
+    removeEntities<CompiledSourceCodeInsideJarExcludeEntity>()
+    removeEntities<LibraryCompiledSourceCodeInsideJarExcludeEntity>()
+  }
+
+  private inline fun <reified T : WorkspaceEntity> MutableEntityStorage.removeEntities() {
+    entities(T::class.java).toList().forEach { removeEntity(it) }
+  }
+
+  private fun ModuleEntity.isTargetModule(targetLabels: Set<Label>, targetModuleNames: Set<String>): Boolean =
+    bazelModuleExtension?.label?.toLabel()?.let { it in targetLabels } == true ||
+      (entitySource as? BazelModuleEntitySource)?.moduleName?.let { it in targetModuleNames } == true
+
+  private fun LibraryEntity.isTargetLibrary(targetLabels: Set<Label>, targetModuleNames: Set<String>): Boolean =
+    bazelLibraryExtension?.label?.toLabel()?.let { it in targetLabels } == true ||
+      (entitySource as? BazelModuleEntitySource)?.moduleName?.let { it in targetModuleNames } == true
 }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -30,6 +30,7 @@ import org.jetbrains.bazel.config.BazelPluginBundle
 import org.jetbrains.bazel.config.BazelPluginConstants
 import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.coroutines.BazelCoroutineService
+import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.label.label
 import org.jetbrains.bazel.performance.bspTracer
 import org.jetbrains.bazel.progress.syncConsole
@@ -42,7 +43,9 @@ import org.jetbrains.bazel.sync.ProjectSyncHook.ProjectSyncHookEnvironment
 import org.jetbrains.bazel.sync.projectPostSyncHooks
 import org.jetbrains.bazel.sync.projectPreSyncHooks
 import org.jetbrains.bazel.sync.projectStructure.ProjectModelApplicatonTask
-import org.jetbrains.bazel.sync.projectSyncHooks
+import org.jetbrains.bazel.sync.projectSyncHooksForScope
+import org.jetbrains.bazel.sync.scope.FullProjectSync
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.ProjectSyncScope
 import org.jetbrains.bazel.sync.status.SyncAlreadyInProgressException
 import org.jetbrains.bazel.sync.status.SyncStatusService
@@ -86,7 +89,7 @@ class ProjectSyncTask(private val project: Project) {
             BazelTaskEventsService.getInstance(project).saveListener(taskId.taskGroupId, taskListener)
 
             val syncJob = BazelCoroutineService.getInstance(project).startAsync(lazy = true) {
-              preSync()
+              preSync(syncScope)
               doSync(taskId, syncScope, buildProject)
             }
 
@@ -160,10 +163,12 @@ class ProjectSyncTask(private val project: Project) {
     }
   }
 
-  private suspend fun preSync() {
+  private suspend fun preSync(syncScope: ProjectSyncScope) {
     log.debug("Running pre sync tasks")
     saveAllFiles()
-    clearSyntheticTargets()
+    if (syncScope is FullProjectSync) {
+      clearSyntheticTargets()
+    }
   }
 
   private suspend fun clearSyntheticTargets() {
@@ -202,7 +207,7 @@ class ProjectSyncTask(private val project: Project) {
 
                 val storage = MutableEntityStorage.create()
                 val deferredApplyActions = mutableListOf<suspend () -> Unit>()
-                syncResult = executeSyncHooks(
+                val syncHooksResult = executeSyncHooks(
                   progressReporter = progressReporter,
                   syncScope = syncScope,
                   buildProject = buildProject,
@@ -217,6 +222,7 @@ class ProjectSyncTask(private val project: Project) {
                     builder = storage
                   ),
                 )
+                syncResult = syncHooksResult.status
                 shouldUpdateProjectModel = syncResult != SyncResultStatus.FAILURE
                 if (shouldUpdateProjectModel) {
                   updateProjectModel(
@@ -225,6 +231,7 @@ class ProjectSyncTask(private val project: Project) {
                     storage = storage,
                     taskId = taskId,
                     deferredApplyActions = deferredApplyActions,
+                    targetsToReplace = syncHooksResult.targetsToReplace,
                   )
                 }
               } finally {
@@ -269,9 +276,9 @@ class ProjectSyncTask(private val project: Project) {
     server: BazelServerFacade,
     importerHelper: WorkspaceImporterHelper,
     deferredApplyActions: MutableList<suspend () -> Unit>,
-  ): SyncResultStatus {
+  ): SyncHooksResult {
     val resolver = BazelWorkspaceResolveService.getInstance(project)
-    val syncStatus =
+    val syncHooksResult =
       bspTracer.spanBuilder("collect.project.details.ms").use {
         // if this bazel build fails, we still want the sync hooks to be executed
         val bazelProject =
@@ -279,8 +286,10 @@ class ProjectSyncTask(private val project: Project) {
             subtaskId = taskId.subTask("base-project-sync-subtask-id"),
             message = BazelPluginBundle.message("console.task.base.sync"),
           ) { subtaskId ->
-            // force full re-sync
-            resolver.invalidateCachedState()
+            if (syncScope is FullProjectSync) {
+              // force full re-sync
+              resolver.invalidateCachedState()
+            }
             resolver.getOrFetchSyncedProject(build = buildProject, taskId = subtaskId).also {
               it.targets.values.filter { it.tagsList.any { it.equals(Constants.NO_IDE) }}.let {
                 if (!it.isEmpty()) {
@@ -293,13 +302,17 @@ class ProjectSyncTask(private val project: Project) {
               }
             }
           }
-        if (bazelProject.hasError && bazelProject.targets.isEmpty()) return@use SyncResultStatus.FAILURE
+        if (bazelProject.hasError && bazelProject.targets.isEmpty()) return@use SyncHooksResult(SyncResultStatus.FAILURE)
+        var targetsToReplace = emptySet<Label>()
         project.syncConsole.withSubtask(
           reporter = progressReporter,
           subtaskId = taskId.subTask("sync-hooks"),
           text = BazelPluginBundle.message("console.task.execute.sync.hooks"),
         ) { subtaskId ->
           val resolvedWorkspace = resolver.getOrFetchResolvedWorkspace(scope = syncScope, taskId = subtaskId)
+          if (syncScope is PartialProjectSync) {
+            targetsToReplace = (syncScope.targetsToSync + resolvedWorkspace.targets.map { it.id }).toSet()
+          }
           val workspaceSnapshot = WorkspaceSnapshotBuilder.build(
             project = project,
             workspaceContext = server.workspaceContext,
@@ -322,21 +335,23 @@ class ProjectSyncTask(private val project: Project) {
               deferredApplyActions = deferredApplyActions,
             )
           // then sync hooks
-          project.projectSyncHooks.forEachSubtask(subtaskId) {
+          project.projectSyncHooksForScope(syncScope).forEachSubtask(subtaskId) {
             it.onSync(environment)
           }
-          deferredApplyActions += { importerHelper.invokeLate(progressReporter, workspaceSnapshot) }
+          if (syncScope is FullProjectSync) {
+            deferredApplyActions += { importerHelper.invokeLate(progressReporter, workspaceSnapshot) }
+          }
         }
 
         if (bazelProject.hasError) {
-          SyncResultStatus.PARTIAL_SUCCESS
+          SyncHooksResult(SyncResultStatus.PARTIAL_SUCCESS, targetsToReplace)
         }
         else {
-          SyncResultStatus.SUCCESS
+          SyncHooksResult(SyncResultStatus.SUCCESS, targetsToReplace)
         }
       }
 
-    return syncStatus
+    return syncHooksResult
   }
 
   private suspend fun updateProjectModel(
@@ -345,6 +360,7 @@ class ProjectSyncTask(private val project: Project) {
     storage: MutableEntityStorage,
     taskId: TaskId,
     deferredApplyActions: MutableList<suspend () -> Unit>,
+    targetsToReplace: Set<Label>,
   ) {
     project.syncConsole.withSubtask(
       reporter = progressReporter,
@@ -356,6 +372,7 @@ class ProjectSyncTask(private val project: Project) {
         scope = syncScope,
         taskId = subtaskId,
         postActions = deferredApplyActions,
+        targetsToReplace = targetsToReplace,
       )
       applicator.apply(storage)
     }
@@ -406,4 +423,9 @@ class ProjectSyncTask(private val project: Project) {
     PARTIAL_SUCCESS,
     FAILURE,
   }
+
+  private data class SyncHooksResult(
+    val status: SyncResultStatus,
+    val targetsToReplace: Set<Label> = emptySet(),
+  )
 }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/Serialization.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/Serialization.kt
@@ -15,6 +15,7 @@ import org.jetbrains.bazel.label.AllRuleTargetsAndFiles
 import org.jetbrains.bazel.label.AmbiguousEmptyTarget
 import org.jetbrains.bazel.label.Apparent
 import org.jetbrains.bazel.label.Canonical
+import org.jetbrains.bazel.label.DependencyLabel
 import org.jetbrains.bazel.label.Main
 import org.jetbrains.bazel.label.Package
 import org.jetbrains.bazel.label.ResolvedLabel
@@ -125,8 +126,16 @@ internal fun createIdToBuildMapType(filePathSuffix: String, rootDir: Path): MVMa
     createAnyValueDataType<PartialBuildTarget>(
       writer = { buffer, item ->
         writeResolvedLabel(buffer, item.id as ResolvedLabel)
+        buffer.putVarInt(item.dependencies.size)
+        for (dependency in item.dependencies) {
+          writeResolvedLabel(buffer, dependency.label as ResolvedLabel)
+          buffer.put(if (dependency.isRuntime) 1 else 0)
+          buffer.put(if (dependency.exported) 1 else 0)
+        }
         writeTargetKind(item.kind, buffer)
         writePath(path = item.baseDirectory.invariantSeparatorsPathString, filePathSuffix = filePathSuffix, buffer = buffer)
+        buffer.put(if (item.generatorName == null) 0 else 1)
+        item.generatorName?.let { buffer.writeString(it) }
         buffer.put(if (item.isManual) 1 else 0)
         buffer.put(if (item.isWorkspace) 1 else 0)
 
@@ -141,8 +150,23 @@ internal fun createIdToBuildMapType(filePathSuffix: String, rootDir: Path): MVMa
       },
       reader = { buffer ->
         val id = readResolvedLabel(buffer)
+        val dependencies =
+          (0 until readVarInt(buffer)).map {
+            DependencyLabel(
+              label = readResolvedLabel(buffer),
+              isRuntime = buffer.get() == 1.toByte(),
+              exported = buffer.get() == 1.toByte(),
+            )
+          }
         val kind = readTargetKind(buffer)
         val baseDirectory = readPath(buffer, rootDir)
+        val generatorName =
+          if (buffer.get() == 1.toByte()) {
+            buffer.readString()
+          }
+          else {
+            null
+          }
         val isManual = buffer.get() == 1.toByte()
         val isWorkspace = buffer.get() == 1.toByte()
 
@@ -157,9 +181,11 @@ internal fun createIdToBuildMapType(filePathSuffix: String, rootDir: Path): MVMa
         }
         PartialBuildTarget(
           id = id,
+          dependencies = dependencies,
           kind = kind,
           baseDirectory = baseDirectory,
           data = data,
+          generatorName = generatorName,
           isManual = isManual,
           isWorkspace = isWorkspace
         )

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetUtils.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetUtils.kt
@@ -38,6 +38,7 @@ import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.label.ResolvedLabel
 import org.jetbrains.bazel.label.SingleTarget
 import org.jetbrains.bazel.label.assumeResolved
+import org.jetbrains.bazel.languages.starlark.repomapping.toCanonicalLabelOrThis
 import org.jetbrains.bazel.languages.starlark.repomapping.toShortString
 import org.jetbrains.bazel.magicmetamodel.LIBRARY_MODULE_PREFIX
 import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
@@ -57,7 +58,7 @@ private fun nowAsDuration() = System.currentTimeMillis().toDuration(DurationUnit
 /**
  * Increment when making breaking changes to [TargetsCacheStorage]
  */
-private const val TARGETS_STORAGE_VERSION: Int = 6
+private const val TARGETS_STORAGE_VERSION: Int = 7
 
 private fun Project.targetsStorageFile(storeVersion: Int): Path = getProjectDataPath("bazel-targets-v$storeVersion.db")
 
@@ -159,7 +160,42 @@ class TargetUtils(private val project: Project, private val coroutineScope: Coro
     }
   }
 
-  private fun calculateDirectDependentsGraph(targets: List<RawBuildTarget>): Map<Label, Set<Label>> {
+  fun mergeTargets(
+    targetsToReplace: Collection<Label>,
+    targets: List<RawBuildTarget>,
+    fileToTarget: Map<Path, List<Label>>,
+  ) {
+    ThreadingAssertions.assertBackgroundThread()
+    val resolvedTargetsToReplace = targetsToReplace.mapNotNull { it.toCanonicalLabelOrThis(project) }.toSet()
+
+    val mergedTargets =
+      db.getAllBuildTargets()
+        .filter { it.id !in resolvedTargetsToReplace }
+        .toList() + targets
+
+    val executableTargets =
+      calculateExecutableTargets(
+        targets = mergedTargets.map { it.id },
+        targetDirectDependentsGraph = calculateDirectDependentsGraph(mergedTargets),
+        labelToTargetInfo = mergedTargets.associateByTo(HashMap(mergedTargets.size)) { it.id },
+      )
+
+    db.mergePartial(
+      targetsToReplace = resolvedTargetsToReplace,
+      fileToTarget = fileToTarget,
+      executableTargets = executableTargets,
+      targets = targets,
+    )
+
+    notifyTargetListUpdated()
+
+    coroutineScope.launch(Dispatchers.IO + NonCancellable) {
+      db.save()
+      lastSaved = nowAsDuration()
+    }
+  }
+
+  private fun calculateDirectDependentsGraph(targets: List<BuildTarget>): Map<Label, Set<Label>> {
     val targetIdToDirectDependentIds = hashMapOf<Label, MutableSet<Label>>()
     for (targetInfo in targets) {
       val dependencies = targetInfo.dependencies
@@ -175,7 +211,7 @@ class TargetUtils(private val project: Project, private val coroutineScope: Coro
   private fun calculateExecutableTargets(
     targets: List<Label>,
     targetDirectDependentsGraph: Map<Label, Set<Label>>,
-    labelToTargetInfo: Map<Label, RawBuildTarget>,
+    labelToTargetInfo: Map<Label, BuildTarget>,
   ): Map<ResolvedLabel, List<Label>> {
     val targetToTransitiveRevertedDependenciesCache = mutableMapOf<Label, Set<Label>>()
     val result = mutableMapOf<ResolvedLabel, MutableList<Label>>()

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetsCacheStorage.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/TargetsCacheStorage.kt
@@ -12,7 +12,6 @@ import com.intellij.util.io.mvstore.openOrResetMap
 import org.h2.mvstore.DataUtils.readVarInt
 import org.h2.mvstore.MVMap
 import org.h2.mvstore.MVStore
-import org.h2.mvstore.WriteBuffer
 import org.h2.mvstore.type.LongDataType
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.bazel.label.AllPackagesBeneath
@@ -27,10 +26,8 @@ import org.jetbrains.bazel.label.Package
 import org.jetbrains.bazel.label.ResolvedLabel
 import org.jetbrains.bazel.label.SingleTarget
 import org.jetbrains.bazel.languages.starlark.repomapping.toCanonicalLabelOrThis
-import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
 import org.jetbrains.bsp.protocol.BuildTarget
 import org.jetbrains.bsp.protocol.PartialBuildTarget
-import java.nio.ByteBuffer
 import java.nio.file.Path
 import kotlin.io.path.invariantSeparatorsPathString
 
@@ -142,9 +139,11 @@ class TargetsCacheStorage(
         hashStream.computeLabelHash(info.id as ResolvedLabel),
         PartialBuildTarget(
           id = info.id,
+          dependencies = info.dependencies,
           kind = info.kind,
           baseDirectory = info.baseDirectory,
           data = info.data,
+          generatorName = info.generatorName,
           isManual = info.isManual,
           isWorkspace = info.isWorkspace
         ),
@@ -180,14 +179,86 @@ class TargetsCacheStorage(
         labelHash,
         PartialBuildTarget(
           id = target.id,
+          dependencies = target.dependencies,
           kind = target.kind,
           baseDirectory = target.baseDirectory,
           data = target.data,
+          generatorName = target.generatorName,
           isManual = target.isManual,
           isWorkspace = target.isWorkspace
         ),
       )
     }
+  }
+
+  fun mergePartial(
+    targetsToReplace: Collection<ResolvedLabel>,
+    fileToTarget: Map<Path, List<Label>>,
+    executableTargets: Map<ResolvedLabel, List<Label>>,
+    targets: List<BuildTarget>,
+  ) {
+    val hashStream = Hashing.xxh3_64()
+      .hashStream()
+    val targetHashesToReplace =
+      targetsToReplace
+        .mapTo(hashSetOf()) { hashStream.computeLabelHash(it) }
+
+    removeTargetsFromFileMap(targetHashesToReplace)
+
+    for ((file, labels) in fileToTarget) {
+      val fileKey = fileToKey(file)
+      val retainedLabels = this.fileToTargets.get(fileKey).orEmpty()
+      val syncedLabels = labels.map { hashStream.computeLabelHash(it as ResolvedLabel) }
+      this.fileToTargets.put(fileKey, (retainedLabels + syncedLabels).distinct())
+    }
+
+    this.targetToExecutableTargets.clear()
+    targetHashesToReplace.forEach { this.labelToTargetInfo.remove(it) }
+
+    for ((label, executableLabels) in executableTargets) {
+      this.targetToExecutableTargets.put(hashStream.computeLabelHash(label), executableLabels.map { hashStream.computeLabelHash(it as ResolvedLabel) })
+    }
+
+    for (target in targets) {
+      val label = target.id as ResolvedLabel
+      val labelHash = hashStream.computeLabelHash(label)
+      this.labelToTargetInfo.put(
+        labelHash,
+        PartialBuildTarget(
+          id = target.id,
+          dependencies = target.dependencies,
+          kind = target.kind,
+          baseDirectory = target.baseDirectory,
+          data = target.data,
+          generatorName = target.generatorName,
+          isManual = target.isManual,
+          isWorkspace = target.isWorkspace
+        ),
+      )
+    }
+  }
+
+  private fun removeTargetsFromFileMap(targetHashesToReplace: Set<Long>) {
+    if (targetHashesToReplace.isEmpty()) return
+
+    val cursor = fileToTargets.cursor(null)
+    val keysToRemove = mutableListOf<Long>()
+    val updatedEntries = mutableListOf<Pair<Long, List<Long>>>()
+
+    while (cursor.hasNext()) {
+      cursor.next()
+      val retainedTargets = cursor.value.filter { it !in targetHashesToReplace }
+      if (retainedTargets.size == cursor.value.size) continue
+
+      if (retainedTargets.isEmpty()) {
+        keysToRemove += cursor.key
+      } else {
+        updatedEntries += cursor.key to retainedTargets
+      }
+    }
+
+    keysToRemove.forEach { fileToTargets.remove(it) }
+    updatedEntries.forEach { (file, targets) -> fileToTargets.put(file, targets) }
   }
 
   fun getTotalFileCount(): Int = fileToTargets.size

--- a/intellij.bazel.core/src/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.bazel.target.sync
 
 import com.intellij.openapi.project.Project
+import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.sync.environment.BazelTargetPersistenceLayer
 import org.jetbrains.bazel.sync.environment.TargetPersistenceSpec
-import org.jetbrains.bazel.sync.status.SyncStatusListener
 import org.jetbrains.bazel.target.targetUtils
 
 internal class TargetUtilsTargetPersistanceLayer : BazelTargetPersistenceLayer {
@@ -12,6 +12,18 @@ internal class TargetUtilsTargetPersistanceLayer : BazelTargetPersistenceLayer {
     spec: TargetPersistenceSpec,
   ) {
     project.targetUtils.saveTargets(
+      targets = spec.targets,
+      fileToTarget = spec.file2Target,
+    )
+  }
+
+  override suspend fun mergePartial(
+    project: Project,
+    targetsToReplace: Collection<Label>,
+    spec: TargetPersistenceSpec,
+  ) {
+    project.targetUtils.mergeTargets(
+      targetsToReplace = targetsToReplace,
       targets = spec.targets,
       fileToTarget = spec.file2Target,
     )

--- a/intellij.bazel.importer/api-dump.txt
+++ b/intellij.bazel.importer/api-dump.txt
@@ -36,6 +36,7 @@ f:org.jetbrains.bazel.sync.ProjectPreSyncHook$ProjectPreSyncHookEnvironment
 org.jetbrains.bazel.sync.ProjectSyncHook
 - sf:Companion:org.jetbrains.bazel.sync.ProjectSyncHook$Companion
 - isEnabled(com.intellij.openapi.project.Project):Z
+- supportsPartialSync():Z
 - a:onSync(org.jetbrains.bazel.sync.ProjectSyncHook$ProjectSyncHookEnvironment,kotlin.coroutines.Continuation):java.lang.Object
 f:org.jetbrains.bazel.sync.ProjectSyncHook$Companion
 f:org.jetbrains.bazel.sync.ProjectSyncHook$ProjectSyncHookEnvironment

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/ProjectSyncHook.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/ProjectSyncHook.kt
@@ -9,6 +9,7 @@ import org.jetbrains.bazel.info.BspTargetInfo
 import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.progress.withSubtask
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.ProjectSyncScope
 import org.jetbrains.bazel.sync.workspace.BazelResolvedWorkspace
 import org.jetbrains.bazel.sync.workspace.BazelWorkspaceResolveService
@@ -26,6 +27,12 @@ interface ProjectSyncHook {
    * It will always be called before each `onSync` call.
    */
   fun isEnabled(project: Project): Boolean = true
+
+  /**
+   * Partial sync passes only a subset of targets through the sync pipeline. Hooks which update
+   * project-wide state should keep the default and run only during full syncs.
+   */
+  fun supportsPartialSync(): Boolean = false
 
   /**
    * Method which will be called during sync. It can perform any type of activity that is part of sync.
@@ -67,6 +74,10 @@ val Project.projectSyncHooks: List<ProjectSyncHook>
     ProjectSyncHook.ep
       .extensionList
       .filter { it.isEnabled(this) }
+
+@ApiStatus.Internal
+fun Project.projectSyncHooksForScope(syncScope: ProjectSyncScope): List<ProjectSyncHook> =
+  projectSyncHooks.filter { syncScope !is PartialProjectSync || it.supportsPartialSync() }
 
 @ApiStatus.Internal
 suspend fun <T> ProjectSyncHook.ProjectSyncHookEnvironment.withSubtask(text: String, block: suspend (subtaskId: TaskId) -> T) =

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
@@ -3,9 +3,12 @@ package org.jetbrains.bazel.sync.hooks
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.environment.TargetPersistenceSpec
 import org.jetbrains.bazel.sync.environment.projectCtx
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 
 // TODO: rename
 internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
+  override fun supportsPartialSync(): Boolean = true
+
   override suspend fun onSync(environment: ProjectSyncHook.ProjectSyncHookEnvironment) {
     val project = environment.project
     val targetPersistanceLayer = project.projectCtx.targetPersistenceLayer
@@ -15,7 +18,13 @@ internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
         targets = workspace.targets,
         file2Target = workspace.fileToTarget,
     )
-    targetPersistanceLayer.saveAll(project, spec)
+    when (val syncScope = environment.syncScope) {
+      is PartialProjectSync -> {
+        val targetsToReplace = syncScope.targetsToSync + workspace.targets.map { it.id }
+        targetPersistanceLayer.mergePartial(project, targetsToReplace, spec)
+      }
+      else -> targetPersistanceLayer.saveAll(project, spec)
+    }
     targetPersistanceLayer.notifyAll(project)
   }
 }

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/DefaultBazelWorkspaceResolveService.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/DefaultBazelWorkspaceResolveService.kt
@@ -46,7 +46,12 @@ internal class DefaultBazelWorkspaceResolveService(private val project: Project)
       when (val state = state) {
         // workspace is already resolved - return the available state and avoid recomputation
         is BazelWorkspaceSyncState.Resolved,
-        -> return state.resolvedWorkspace
+        -> {
+          if (scope !is PartialProjectSync) {
+            return state.resolvedWorkspace
+          }
+          state.bazelProject
+        }
 
         // workspace is not in the correct state - try to pull the required state
         BazelWorkspaceSyncState.Unsynced,
@@ -98,7 +103,14 @@ internal class DefaultBazelWorkspaceResolveService(private val project: Project)
         }
       }
     return workspace
-      .also { state = BazelWorkspaceSyncState.Resolved(synced, it) }
+      .also {
+        state =
+          if (scope is PartialProjectSync) {
+            BazelWorkspaceSyncState.Synced(synced)
+          } else {
+            BazelWorkspaceSyncState.Resolved(synced, it)
+          }
+      }
   }
 
   override suspend fun invalidateCachedState() {

--- a/pluginTests/test/org/jetbrains/bazel/sync/target/TargetsCacheStorageTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/sync/target/TargetsCacheStorageTest.kt
@@ -5,6 +5,7 @@ import com.intellij.testFramework.junit5.TestApplication
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import org.jetbrains.bazel.label.DependencyLabel
 import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.label.ResolvedLabel
 import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
@@ -122,9 +123,60 @@ class TargetsCacheStorageTest : WorkspaceModelBaseTest() {
   }
 
   @Test
+  fun `mergePartial replaces only requested targets and removes stale file mappings`() {
+    val replacedLabel: ResolvedLabel = Label.parse("@//lib:core") as ResolvedLabel
+    val retainedLabel: ResolvedLabel = Label.parse("@//app:tool") as ResolvedLabel
+
+    val oldFile = projectBasePath.resolve("lib/Old.kt")
+    val sharedFile = projectBasePath.resolve("shared/Shared.kt")
+    val retainedFile = projectBasePath.resolve("app/Tool.kt")
+    val newSharedFile = projectBasePath.resolve("lib/New.kt")
+
+    storage.reset(
+      fileToTarget = mapOf(
+        oldFile to listOf(replacedLabel),
+        sharedFile to listOf(replacedLabel, retainedLabel),
+        retainedFile to listOf(retainedLabel),
+        newSharedFile to listOf(retainedLabel),
+      ),
+      executableTargets = mapOf(
+        replacedLabel to listOf(replacedLabel),
+        retainedLabel to listOf(replacedLabel),
+      ),
+      targets = listOf(
+        TestBuildTargetFactory.createSimpleJavaLibraryTarget(id = replacedLabel),
+        TestBuildTargetFactory.createSimpleJavaLibraryTarget(id = retainedLabel),
+      ),
+    )
+
+    storage.mergePartial(
+      targetsToReplace = listOf(replacedLabel),
+      fileToTarget = mapOf(newSharedFile to listOf(replacedLabel)),
+      executableTargets = mapOf(retainedLabel to listOf(retainedLabel)),
+      targets = listOf(TestBuildTargetFactory.createSimpleKotlinLibraryTarget(id = replacedLabel)),
+    )
+
+    storage.getTargetsForPath(oldFile).shouldBeNull()
+    storage.getTargetsForPath(sharedFile)!!.shouldContainExactly(listOf(retainedLabel))
+    storage.getTargetsForPath(retainedFile)!!.shouldContainExactly(listOf(retainedLabel))
+    storage.getTargetsForPath(newSharedFile)!!.shouldContainExactly(listOf(retainedLabel, replacedLabel))
+    storage.getBuildTargetForLabel(replacedLabel)!!.kind.kind shouldBe "kt_jvm_library"
+    storage.getBuildTargetForLabel(retainedLabel)!!.id shouldBe retainedLabel
+    storage.getExecutableTargetsForTarget(replacedLabel).shouldBeNull()
+    storage.getExecutableTargetsForTarget(retainedLabel)!!.shouldContainExactly(listOf(retainedLabel))
+    storage.getTotalTargetCount() shouldBe 2
+  }
+
+  @Test
   fun `persistence after save and reopen`() {
     val label: ResolvedLabel = Label.parse("@//persist:me") as ResolvedLabel
-    val target = TestBuildTargetFactory.createSimpleJavaLibraryTarget(id = label)
+    val dependency: ResolvedLabel = Label.parse("@//persist:dep") as ResolvedLabel
+    val target =
+      TestBuildTargetFactory.createSimpleJavaLibraryTarget(id = label)
+        .copy(
+          dependencies = listOf(DependencyLabel(dependency, isRuntime = true, exported = true)),
+          generatorName = "generated_me",
+        )
 
     storage.setTargets(listOf(target))
     storage.save()
@@ -135,5 +187,7 @@ class TargetsCacheStorageTest : WorkspaceModelBaseTest() {
 
     val restored = storage.getBuildTargetForLabel(label)
     restored!!.id shouldBe label
+    restored.dependencies shouldBe listOf(DependencyLabel(dependency, isRuntime = true, exported = true))
+    restored.generatorName shouldBe "generated_me"
   }
 }

--- a/pluginTests/test/org/jetbrains/bazel/sync/task/ProjectSyncTaskTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/sync/task/ProjectSyncTaskTest.kt
@@ -13,10 +13,13 @@ import org.jetbrains.bazel.impl.flow.sync.DisabledTestProjectSyncHook
 import org.jetbrains.bazel.impl.flow.sync.TestProjectPostSyncHook
 import org.jetbrains.bazel.impl.flow.sync.TestProjectPreSyncHook
 import org.jetbrains.bazel.impl.flow.sync.TestProjectSyncHook
+import org.jetbrains.bazel.label.Label
 import org.jetbrains.bazel.server.connection.BazelServerService
 import org.jetbrains.bazel.sync.ProjectPostSyncHook
 import org.jetbrains.bazel.sync.ProjectPreSyncHook
 import org.jetbrains.bazel.sync.ProjectSyncHook
+import org.jetbrains.bazel.sync.ProjectSyncHook.ProjectSyncHookEnvironment
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 import org.jetbrains.bazel.sync.scope.SecondPhaseSync
 import org.jetbrains.bazel.sync.workspace.BazelResolvedWorkspace
 import org.jetbrains.bazel.sync.workspace.BazelWorkspaceResolveService
@@ -86,5 +89,43 @@ class ProjectSyncTaskTest : MockProjectBaseTest() {
 
     postSyncHook.wasCalled shouldBe true
     disabledPostSyncHook.wasCalled shouldBe false
+  }
+
+  @Test
+  fun `partial sync should call only partial-aware sync hooks`() = Disposer.newDisposable().use { disposable ->
+    project.registerOrReplaceServiceInstance(BazelServerService::class.java, MockBuildServerService(BuildServerMock()), disposable)
+    project.registerOrReplaceServiceInstance(
+      BazelWorkspaceResolveService::class.java,
+      BazelWorkspaceResolveServiceMock(
+        resolvedWorkspace =
+          BazelResolvedWorkspace(
+            targets = listOf(),
+          ),
+        bazelProject = WorkspaceBuildTargetsResult(mapOf(), setOf()),
+      ),
+      disposable,
+    )
+
+    val partialAwareHook = PartialAwareTestProjectSyncHook()
+    ProjectSyncHook.ep.registerExtension(partialAwareHook)
+    val fullOnlyHook = TestProjectSyncHook()
+    ProjectSyncHook.ep.registerExtension(fullOnlyHook)
+
+    runBlocking {
+      ProjectSyncTask(project).sync(syncScope = PartialProjectSync(listOf(Label.parse("//foo:bar"))), false)
+    }
+
+    partialAwareHook.wasCalled shouldBe true
+    fullOnlyHook.wasCalled shouldBe false
+  }
+
+  private class PartialAwareTestProjectSyncHook : ProjectSyncHook {
+    var wasCalled: Boolean = false
+
+    override fun supportsPartialSync(): Boolean = true
+
+    override suspend fun onSync(environment: ProjectSyncHookEnvironment) {
+      wasCalled = true
+    }
   }
 }


### PR DESCRIPTION
## Why
The target resync action already creates `PartialProjectSync`, but the sync pipeline still treated model application and target persistence as full-sync-only. This makes target refresh either unsupported or too broad.

## What
- Fetch specific targets for partial sync instead of reusing a cached full resolved workspace
- Add an opt-in partial-sync hook contract and merge refreshed targets into `TargetUtils`
- Apply partial workspace model changes by replacing matching target modules while preserving project-wide entities
- Persist target dependency/generator metadata so executable target mappings can be rebuilt after partial merges
- Keep project-wide late importer work on full syncs only and update partial-sync cache tests

## Risk Assessment
Medium — this touches core sync plumbing, but the behavioral change is limited to the existing partial-sync path; full sync continues to replace all Bazel-owned workspace model entities.

## References
- Alternative implementation for #392
- `git -c core.fsmonitor=false diff --check`
- `bazel build //intellij.bazel.commons:commons`
- `bazel build //intellij.bazel.importer:importer //intellij.bazel.core:core //python/intellij.bazel.python.common:bazel-python-common` currently stops in existing importer/generated-code errors (`instrumentation`, `forEachExtensionSafeInline`, `WorkspaceFileSetExclusionCondition`)

Generated with Codex
