### PR TITLE
fix name collision in java_info

### DIFF
--- a/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
+++ b/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
@@ -64,7 +64,8 @@ def get_jdeps(ctx, target):
     jdeps = get_raw_jdeps(target)
     materialized_jdeps = []
     for raw_jdeps_file in jdeps:
-            materialized_jdeps_file = ctx.actions.declare_file("materialized_" + target.label.name + "_" + raw_jdeps_file.basename)
+        materialized_jdeps_file = ctx.actions.declare_file("materialized_" + target.label.name + "_" + raw_jdeps_file.basename)
+        ctx.actions.run_shell(
             inputs = [raw_jdeps_file],
             outputs = [materialized_jdeps_file],
             progress_message = "(IntelliJ Bazel plugin) Materializing jdeps %s" % raw_jdeps_file,

--- a/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
+++ b/intellij.bazel.connector/resources/aspects/rules/java/java_info.bzl.template
@@ -64,8 +64,7 @@ def get_jdeps(ctx, target):
     jdeps = get_raw_jdeps(target)
     materialized_jdeps = []
     for raw_jdeps_file in jdeps:
-        materialized_jdeps_file = ctx.actions.declare_file("materialized_" + raw_jdeps_file.basename)
-        ctx.actions.run_shell(
+            materialized_jdeps_file = ctx.actions.declare_file("materialized_" + target.label.name + "_" + raw_jdeps_file.basename)
             inputs = [raw_jdeps_file],
             outputs = [materialized_jdeps_file],
             progress_message = "(IntelliJ Bazel plugin) Materializing jdeps %s" % raw_jdeps_file,


### PR DESCRIPTION
Hi,
using the bazel ij plugin with bzlmod using bazel 7.7 with a WORKSPACE and basically empty MODULE.bazel, I got this error (redacted specific names):
```
 file 'external/my_repo/path/to/proto/materialized_api_proto.jdeps' is generated by these conflicting actions:
    Label: @@my_repo//path/to/proto:api_proto_java, @@my_repo//path/to/proto:api_proto
    Aspects: [//.bazelbsp/aspects:core.bzl%bsp_target_info_aspect], [@@my_repo//path/to/proto/rules:java_proto_library.bzl%_java_proto_aspect,//.bazelbsp/aspects:core.bzl%bsp_target_info_aspect]
    RuleClass: java_proto_library_compat rule, proto_library rule
    JavaActionClass: class com.google.devtools.build.lib.analysis.actions.StarlarkAction
    Configuration: e2de5d7b3a1a72d9394a19cd59434b09ebdc723b8477fc93c33c67836047b38a
    Mnemonic: IJBazelPluginMaterializeJdeps
    Action key: 20f14e6e9945ef482ffdc49d15d83137e039e7bbbf6264cf7c0447b3c145a1b8, e6fd7a46fca35e3590c9e6881ff4364334b230dce651f92d032f935d69ed1606
    Progress message: (IntelliJ Bazel plugin) Materializing jdeps <generated file external/my_repo/path/to/proto/api_proto.jdeps>
    Action describeKey: (IntelliJ Bazel plugin) Materializing jdeps <generated file external/my_repo/path/to/proto/api_proto.jdeps>
      Environment variable: BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
      Environment variable: PATH=/bin:/usr/bin:/usr/local/bin
      Argument: /bin/bash
      Argument: -c
      Argument: 'cp '\''bazel-out/darwin_arm64-fastbuild/bin/external/my_repo/path/to/proto/api_proto.jdeps'\''
    '\''bazel-out/darwin_arm64-fastbuild/bin/external/my_repo/path/to/proto/materialized_api_proto.jdeps'\'''
      Output paths mode: OFF
    PrimaryInput: File:[[<execution_root>]bazel-out/darwin_arm64-fastbuild/bin]external/my_repo/path/to/proto/api_proto.jdeps
    PrimaryOutput: File:[[<execution_root>]bazel-out/darwin_arm64-fastbuild/bin]external/my_repo/path/to/proto/materialized_api_proto.jdeps
    Owner information: @@my_repo//path/to/proto:api_proto_java#//.bazelbsp/aspects:core.bzl%bsp_target_info_aspect ConfiguredTargetKey{label=@@my_repo//path/to/proto:api_proto_java,
    config=BuildConfigurationKey[e2de5d7b3a1a72d9394a19cd59434b09ebdc723b8477fc93c33c67836047b38a]} {}, [@@my_repo//path/to/proto:api_proto#@@my_repo//path/to/proto/rules:java_proto_library.bzl%_java_proto_aspect
    ConfiguredTargetKey{label=@@my_repo//path/to/proto:api_proto, config=BuildConfigurationKey[e2de5d7b3a1a72d9394a19cd59434b09ebdc723b8477fc93c33c67836047b38a]} {}]#//.bazelbsp/aspects:core.bzl%bsp_target_info_aspect
    ConfiguredTargetKey{label=@@my_repo//path/to/proto:api_proto, config=BuildConfigurationKey[e2de5d7b3a1a72d9394a19cd59434b09ebdc723b8477fc93c33c67836047b38a]} {}
    MandatoryInputs: are equal
```

a simple addition of the original target seem to fix the problem.
I'm not sure if there are other places that depend on this name... so this is more of a bug report rather than a solution.
Thanks!