### PR TITLE
Fix Specs2 class filters for rules_scala tests

### DIFF
--- a/intellij.bazel.commons/src/org/jetbrains/bsp/protocol/BuildTarget.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bsp/protocol/BuildTarget.kt
@@ -96,6 +96,8 @@ data class ScalaBuildTarget(
   val scalaVersion: String,
   val sdkJars: List<Path>,
   val scalacOptions: List<String>,
+  val testSuiteClass: String? = null,
+  val testSuiteLabel: String? = null,
 ) : BuildTargetData
 
 @ClassDiscriminator(4)

--- a/intellij.bazel.connector/resources/aspects/rules/scala/scala_info.bzl.template
+++ b/intellij.bazel.connector/resources/aspects/rules/scala/scala_info.bzl.template
@@ -74,6 +74,12 @@ def extract_scala_info(target, ctx, output_groups, **kwargs):
         common_scalac_opts = []
     scala_info["scalac_opts"] = common_scalac_opts + getattr(ctx.rule.attr, "scalacopts", [])
     scala_info["scalatest_classpath_targets"] = extract_scalatest_classpath_targets(rule_attr)
+    suite_class = getattr(rule_attr, "suite_class", None)
+    if suite_class != None:
+        scala_info["test_suite_class"] = suite_class
+    suite_label = getattr(rule_attr, "suite_label", None)
+    if suite_label != None:
+        scala_info["test_suite_label"] = str(getattr(suite_label, "label", suite_label))
 
     result = dict(scala_target_info = struct(**scala_info)) 
 

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/sync/proto/bsp_target_info.proto
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/sync/proto/bsp_target_info.proto
@@ -73,6 +73,8 @@ message ScalaTargetInfo {
   repeated string scalac_opts = 1;
   repeated ArtifactLocation compiler_classpath = 2;
   repeated string scalatest_classpath_targets = 4;
+  string test_suite_class = 5;
+  string test_suite_label = 6;
 }
 
 message KotlincPluginOption {

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelTestFilterNormalizer.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelTestFilterNormalizer.kt
@@ -1,0 +1,52 @@
+package org.jetbrains.bazel.run.test
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.VisibleForTesting
+import org.jetbrains.bsp.protocol.BuildTarget
+import org.jetbrains.bsp.protocol.ScalaBuildTarget
+import java.util.regex.Pattern
+
+private const val SPECS2_DISCOVERED_SUITE = "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite"
+private const val SPECS2_DISCOVERY_LABEL_SUFFIX = "//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery"
+
+internal fun normalizeBazelTestFilter(
+  project: Project,
+  target: BuildTarget,
+  rawFilter: String?,
+  testExecutableArguments: List<String>,
+): String? =
+  normalizeBazelTestFilter(
+    target = target,
+    rawFilter = rawFilter,
+    testExecutableArguments = testExecutableArguments,
+    useJetBrainsTestRunner = project.useJetBrainsTestRunner(),
+  )
+
+@VisibleForTesting
+internal fun normalizeBazelTestFilter(
+  target: BuildTarget,
+  rawFilter: String?,
+  testExecutableArguments: List<String>,
+  useJetBrainsTestRunner: Boolean,
+): String? {
+  if (rawFilter == null) return null
+  if (useJetBrainsTestRunner) return rawFilter
+  if (testExecutableArguments.isNotEmpty()) return rawFilter
+  if (!target.isRulesScalaSpecs2DiscoveredSuite()) return rawFilter
+  if (!rawFilter.looksLikeJvmClassName()) return rawFilter
+
+  return "^${Pattern.quote(rawFilter)}(#.*)?$"
+}
+
+private fun BuildTarget.isRulesScalaSpecs2DiscoveredSuite(): Boolean =
+  data.filterIsInstance<ScalaBuildTarget>().any {
+    it.testSuiteClass == SPECS2_DISCOVERED_SUITE ||
+      it.testSuiteLabel?.endsWith(SPECS2_DISCOVERY_LABEL_SUFFIX) == true
+  }
+
+private fun String.looksLikeJvmClassName(): Boolean =
+  JVM_CLASS_NAME_PATTERN.matches(this)
+
+// Deliberately excludes `$` nested-class names until their Specs2/rules_scala
+// runtime shape is verified; see docs/dev/scala_specs2_test_filter_fix_design_v2.md.
+private val JVM_CLASS_NAME_PATTERN = Regex("[A-Za-z_][A-Za-z\\d_]*(\\.[A-Za-z_][A-Za-z\\d_]*)*")

--- a/intellij.bazel.core/src/org/jetbrains/bazel/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
@@ -17,6 +17,7 @@ import org.jetbrains.bazel.commons.RuleType
 import org.jetbrains.bazel.config.BazelFeatureFlags
 import org.jetbrains.bazel.coroutines.BazelCoroutineService
 import org.jetbrains.bazel.debug.actions.StarlarkDebugAction
+import org.jetbrains.bazel.run.test.normalizeBazelTestFilter
 import org.jetbrains.bazel.run.synthetic.SyntheticRunTargetUtils
 import org.jetbrains.bazel.runnerAction.BazelRunnerAction
 import org.jetbrains.bazel.runnerAction.BuildTargetAction
@@ -143,6 +144,13 @@ internal fun DefaultActionGroup.fillWithEligibleActions(
   callerPsiElement: PsiElement? = null,
 ): DefaultActionGroup {
   val kind = target.kind
+  // Only imported BuildTargets carry Scala suite metadata; future synthetic ExecutableTargets may not.
+  val targetSingleTestFilter =
+    if (target is BuildTarget) {
+      normalizeBazelTestFilter(project, target, singleTestFilter, testExecutableArguments)
+    } else {
+      singleTestFilter
+    }
 
   val supportedExecutors = getSupportedExecutors(project, target)
 
@@ -159,7 +167,7 @@ internal fun DefaultActionGroup.fillWithEligibleActions(
           project,
           target,
           executor = executor,
-          singleTestFilter = singleTestFilter,
+          singleTestFilter = targetSingleTestFilter,
           testExecutableArguments = testExecutableArguments,
           callerPsiElement = callerPsiElement,
         ),

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/languages/scala/ScalaLanguagePlugin.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/languages/scala/ScalaLanguagePlugin.kt
@@ -70,6 +70,8 @@ class ScalaLanguagePlugin: JvmLanguagePluginMixin {
         scalaVersion = sdk.version,
         sdkJars = sdk.compilerJars,
         scalacOptions = target.scalaTargetInfo.scalacOptsList,
+        testSuiteClass = target.scalaTargetInfo.testSuiteClass.ifEmpty { null },
+        testSuiteLabel = target.scalaTargetInfo.testSuiteLabel.ifEmpty { null },
       ))
     }
 

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/targetKind/GenericBazelRules.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/targetKind/GenericBazelRules.kt
@@ -19,6 +19,7 @@ private class GenericBazelRules : TargetKindProvider {
       TargetKind("scala_library", setOf(LanguageClass.JAVA, LanguageClass.SCALA), RuleType.LIBRARY),
       TargetKind("scala_binary", setOf(LanguageClass.JAVA, LanguageClass.SCALA), RuleType.BINARY),
       TargetKind("scala_test", setOf(LanguageClass.JAVA, LanguageClass.SCALA), RuleType.TEST),
+      TargetKind("scala_junit_test", setOf(LanguageClass.JAVA, LanguageClass.SCALA), RuleType.TEST),
       // rules_jvm from IntelliJ monorepo
       TargetKind("jvm_library", setOf(LanguageClass.JAVA, LanguageClass.KOTLIN), RuleType.LIBRARY),
       TargetKind("_jvm_library_jps", setOf(LanguageClass.JAVA, LanguageClass.KOTLIN), RuleType.LIBRARY),
@@ -45,6 +46,9 @@ private class GenericBazelRules : TargetKindProvider {
       }
       if (target.javaCommon.jvmTarget) {
         add(LanguageClass.JAVA)
+      }
+      if (target.hasScalaTargetInfo()) {
+        add(LanguageClass.SCALA)
       }
       if (target.hasPythonTargetInfo()) {
         add(LanguageClass.PYTHON)

--- a/pluginTests/test/org/jetbrains/bazel/info/BspTargetInfoTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/info/BspTargetInfoTest.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.bazel.info
+
+import com.google.protobuf.TextFormat
+import io.kotest.matchers.shouldBe
+import org.jetbrains.bazel.info.BspTargetInfo.TargetInfo
+import org.junit.jupiter.api.Test
+
+class BspTargetInfoTest {
+  @Test
+  fun `Scala target info parses test suite metadata from textproto`() {
+    val builder = TargetInfo.newBuilder()
+
+    TextFormat.merge(
+      """
+      scala_target_info {
+        test_suite_class: "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite"
+        test_suite_label: "@rules_scala//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery"
+      }
+      """.trimIndent(),
+      builder,
+    )
+
+    builder.build().scalaTargetInfo.testSuiteClass shouldBe
+      "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite"
+    builder.build().scalaTargetInfo.testSuiteLabel shouldBe
+      "@rules_scala//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery"
+  }
+}

--- a/pluginTests/test/org/jetbrains/bazel/run/test/BazelTestFilterNormalizerTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/run/test/BazelTestFilterNormalizerTest.kt
@@ -1,0 +1,99 @@
+package org.jetbrains.bazel.run.test
+
+import io.kotest.matchers.shouldBe
+import org.jetbrains.bazel.commons.LanguageClass
+import org.jetbrains.bazel.commons.RuleType
+import org.jetbrains.bazel.label.Label
+import org.jetbrains.bazel.test.framework.target.TestBuildTargetFactory
+import org.jetbrains.bsp.protocol.BuildTargetData
+import org.jetbrains.bsp.protocol.ScalaBuildTarget
+import org.junit.jupiter.api.Test
+
+class BazelTestFilterNormalizerTest {
+  @Test
+  fun `null filter stays null`() {
+    normalizeBazelTestFilter(specs2Target(), null, emptyList(), useJetBrainsTestRunner = false) shouldBe null
+  }
+
+  @Test
+  fun `JetBrains test runner keeps raw filter`() {
+    normalizeBazelTestFilter(specs2Target(), "com.example.FieldMasksTest", emptyList(), useJetBrainsTestRunner = true) shouldBe
+      "com.example.FieldMasksTest"
+  }
+
+  @Test
+  fun `non Specs2 target keeps raw filter`() {
+    normalizeBazelTestFilter(scalaTarget(), "com.example.FieldMasksTest", emptyList(), useJetBrainsTestRunner = false) shouldBe
+      "com.example.FieldMasksTest"
+  }
+
+  @Test
+  fun `Specs2 discovered suite rewrites class filter`() {
+    normalizeBazelTestFilter(specs2Target(), "com.example.FieldMasksTest", emptyList(), useJetBrainsTestRunner = false) shouldBe
+      "^\\Qcom.example.FieldMasksTest\\E(#.*)?$"
+  }
+
+  @Test
+  fun `Specs2 discovered suite can be identified by discovery label`() {
+    normalizeBazelTestFilter(specs2TargetByLabel(), "com.example.FieldMasksTest", emptyList(), useJetBrainsTestRunner = false) shouldBe
+      "^\\Qcom.example.FieldMasksTest\\E(#.*)?$"
+  }
+
+  @Test
+  fun `Specs2 discovered suite can be identified by canonical bzlmod discovery label`() {
+    normalizeBazelTestFilter(
+      specs2TargetByLabel("@@rules_scala~//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery"),
+      "com.example.FieldMasksTest",
+      emptyList(),
+      useJetBrainsTestRunner = false,
+    ) shouldBe "^\\Qcom.example.FieldMasksTest\\E(#.*)?$"
+  }
+
+  @Test
+  fun `extra test arguments keep raw filter`() {
+    normalizeBazelTestFilter(specs2Target(), "com.example.FieldMasksTest", listOf("-t", "example"), useJetBrainsTestRunner = false) shouldBe
+      "com.example.FieldMasksTest"
+  }
+
+  @Test
+  fun `regex like filter stays raw`() {
+    normalizeBazelTestFilter(specs2Target(), "com.example.FieldMasksTest#.*", emptyList(), useJetBrainsTestRunner = false) shouldBe
+      "com.example.FieldMasksTest#.*"
+  }
+
+  private fun specs2Target() =
+    scalaTarget(
+      ScalaBuildTarget(
+        scalaVersion = "2.13.16",
+        sdkJars = emptyList(),
+        scalacOptions = emptyList(),
+        testSuiteClass = "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite",
+      ),
+    )
+
+  private fun specs2TargetByLabel(
+    label: String = "@rules_scala//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery",
+  ) =
+    scalaTarget(
+      ScalaBuildTarget(
+        scalaVersion = "2.13.16",
+        sdkJars = emptyList(),
+        scalacOptions = emptyList(),
+        testSuiteLabel = label,
+      ),
+    )
+
+  private fun scalaTarget(
+    data: BuildTargetData = ScalaBuildTarget(
+      scalaVersion = "2.13.16",
+      sdkJars = emptyList(),
+      scalacOptions = emptyList(),
+    ),
+  ) = TestBuildTargetFactory.createSimpleTarget(
+    id = Label.parse("//test:specs2"),
+    kind = "scala_junit_test",
+    ruleType = RuleType.TEST,
+    languages = setOf(LanguageClass.JAVA, LanguageClass.SCALA),
+    data = listOf(data),
+  )
+}

--- a/pluginTests/test/org/jetbrains/bazel/sync/workspace/targetKind/TargetKindServiceTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/sync/workspace/targetKind/TargetKindServiceTest.kt
@@ -4,12 +4,14 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.jetbrains.bazel.commons.LanguageClass.JAVA
+import org.jetbrains.bazel.commons.LanguageClass.SCALA
 import org.jetbrains.bazel.commons.RuleType.BINARY
 import org.jetbrains.bazel.commons.RuleType.LIBRARY
 import org.jetbrains.bazel.commons.RuleType.TEST
 import org.jetbrains.bazel.commons.RuleType.UNKNOWN
 import org.jetbrains.bazel.commons.TargetKind
 import org.jetbrains.bazel.info.BspTargetInfo.JavaCommonInfo
+import org.jetbrains.bazel.info.BspTargetInfo.ScalaTargetInfo
 import org.jetbrains.bazel.info.BspTargetInfo.TargetInfo
 import org.jetbrains.bazel.test.framework.BazelTestApplication
 import org.junit.jupiter.api.Test
@@ -27,6 +29,12 @@ class TargetKindServiceTest {
   }
 
   @Test
+  fun `fromTargetInfo resolves scala_junit_test as Scala test`() {
+    val target = targetInfo("scala_junit_test")
+    service.fromTargetInfo(target) shouldBe TargetKind("scala_junit_test", setOf(JAVA, SCALA), TEST)
+  }
+
+  @Test
   fun `fromTargetInfo resolves known kind with transition prefix`() {
     val target = targetInfo("_transition_java_library")
     service.fromTargetInfo(target) shouldBe TargetKind("java_library", setOf(JAVA), LIBRARY)
@@ -36,6 +44,12 @@ class TargetKindServiceTest {
   fun `fromTargetInfo infers library for unknown jvm kind when not executable`() {
     val target = targetInfo("custom_lib", executable = false, jvmTarget = true)
     service.fromTargetInfo(target) shouldBe TargetKind("custom_lib", setOf(JAVA), LIBRARY)
+  }
+
+  @Test
+  fun `fromTargetInfo infers Scala language from aspect data`() {
+    val target = targetInfo("custom_scala_test", executable = true, jvmTarget = true, scalaTarget = true)
+    service.fromTargetInfo(target) shouldBe TargetKind("custom_scala_test", setOf(JAVA, SCALA), TEST)
   }
 
   @Test
@@ -148,6 +162,7 @@ private fun targetInfo(
   kind: String,
   executable: Boolean = false,
   jvmTarget: Boolean = false,
+  scalaTarget: Boolean = false,
 ): TargetInfo =
   TargetInfo.newBuilder()
     .setKind(kind)
@@ -155,6 +170,9 @@ private fun targetInfo(
     .apply {
       if (jvmTarget) {
         javaCommon = JavaCommonInfo.newBuilder().setJvmTarget(true).build()
+      }
+      if (scalaTarget) {
+        scalaTargetInfo = ScalaTargetInfo.newBuilder().build()
       }
     }
     .build()

--- a/protobuf/src/main/gen/org/jetbrains/bazel/info/BspTargetInfo.java
+++ b/protobuf/src/main/gen/org/jetbrains/bazel/info/BspTargetInfo.java
@@ -132,7 +132,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         relativePath_ = s;
@@ -154,7 +154,7 @@ public final class BspTargetInfo {
         getRelativePathBytes() {
       java.lang.Object ref = relativePath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         relativePath_ = b;
@@ -198,7 +198,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         rootPath_ = s;
@@ -220,7 +220,7 @@ public final class BspTargetInfo {
         getRootPathBytes() {
       java.lang.Object ref = rootPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         rootPath_ = b;
@@ -641,7 +641,7 @@ public final class BspTargetInfo {
           getRelativePathBytes() {
         java.lang.Object ref = relativePath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           relativePath_ = b;
@@ -787,7 +787,7 @@ public final class BspTargetInfo {
           getRootPathBytes() {
         java.lang.Object ref = rootPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           rootPath_ = b;
@@ -1050,7 +1050,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         label_ = s;
@@ -1066,7 +1066,7 @@ public final class BspTargetInfo {
         getLabelBytes() {
       java.lang.Object ref = label_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         label_ = b;
@@ -1151,7 +1151,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         configuration_ = s;
@@ -1172,7 +1172,7 @@ public final class BspTargetInfo {
         getConfigurationBytes() {
       java.lang.Object ref = configuration_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         configuration_ = b;
@@ -1596,7 +1596,7 @@ public final class BspTargetInfo {
           getLabelBytes() {
         java.lang.Object ref = label_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           label_ = b;
@@ -1834,7 +1834,7 @@ public final class BspTargetInfo {
           getConfigurationBytes() {
         java.lang.Object ref = configuration_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           configuration_ = b;
@@ -4532,7 +4532,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         mainClass_ = s;
@@ -4548,7 +4548,7 @@ public final class BspTargetInfo {
         getMainClassBytes() {
       java.lang.Object ref = mainClass_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         mainClass_ = b;
@@ -4616,7 +4616,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         resourceStripPrefix_ = s;
@@ -4632,7 +4632,7 @@ public final class BspTargetInfo {
         getResourceStripPrefixBytes() {
       java.lang.Object ref = resourceStripPrefix_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         resourceStripPrefix_ = b;
@@ -5327,7 +5327,7 @@ public final class BspTargetInfo {
           getMainClassBytes() {
         java.lang.Object ref = mainClass_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           mainClass_ = b;
@@ -5517,7 +5517,7 @@ public final class BspTargetInfo {
           getResourceStripPrefixBytes() {
         java.lang.Object ref = resourceStripPrefix_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           resourceStripPrefix_ = b;
@@ -6831,7 +6831,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         sourceVersion_ = s;
@@ -6847,7 +6847,7 @@ public final class BspTargetInfo {
         getSourceVersionBytes() {
       java.lang.Object ref = sourceVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         sourceVersion_ = b;
@@ -6870,7 +6870,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         targetVersion_ = s;
@@ -6886,7 +6886,7 @@ public final class BspTargetInfo {
         getTargetVersionBytes() {
       java.lang.Object ref = targetVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         targetVersion_ = b;
@@ -7406,7 +7406,7 @@ public final class BspTargetInfo {
           getSourceVersionBytes() {
         java.lang.Object ref = sourceVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           sourceVersion_ = b;
@@ -7478,7 +7478,7 @@ public final class BspTargetInfo {
           getTargetVersionBytes() {
         java.lang.Object ref = targetVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           targetVersion_ = b;
@@ -7907,6 +7907,30 @@ public final class BspTargetInfo {
      */
     com.google.protobuf.ByteString
         getScalatestClasspathTargetsBytes(int index);
+
+    /**
+     * <code>string test_suite_class = 5;</code>
+     * @return The testSuiteClass.
+     */
+    java.lang.String getTestSuiteClass();
+    /**
+     * <code>string test_suite_class = 5;</code>
+     * @return The bytes for testSuiteClass.
+     */
+    com.google.protobuf.ByteString
+        getTestSuiteClassBytes();
+
+    /**
+     * <code>string test_suite_label = 6;</code>
+     * @return The testSuiteLabel.
+     */
+    java.lang.String getTestSuiteLabel();
+    /**
+     * <code>string test_suite_label = 6;</code>
+     * @return The bytes for testSuiteLabel.
+     */
+    com.google.protobuf.ByteString
+        getTestSuiteLabelBytes();
   }
   /**
    * Protobuf type {@code bazelbsp.ScalaTargetInfo}
@@ -7926,6 +7950,8 @@ public final class BspTargetInfo {
       compilerClasspath_ = java.util.Collections.emptyList();
       scalatestClasspathTargets_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
+      testSuiteClass_ = "";
+      testSuiteLabel_ = "";
     }
 
     @java.lang.Override
@@ -8063,6 +8089,84 @@ public final class BspTargetInfo {
       return scalatestClasspathTargets_.getByteString(index);
     }
 
+    public static final int TEST_SUITE_CLASS_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object testSuiteClass_ = "";
+    /**
+     * <code>string test_suite_class = 5;</code>
+     * @return The testSuiteClass.
+     */
+    @java.lang.Override
+    public java.lang.String getTestSuiteClass() {
+      java.lang.Object ref = testSuiteClass_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        testSuiteClass_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string test_suite_class = 5;</code>
+     * @return The bytes for testSuiteClass.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTestSuiteClassBytes() {
+      java.lang.Object ref = testSuiteClass_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        testSuiteClass_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TEST_SUITE_LABEL_FIELD_NUMBER = 6;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object testSuiteLabel_ = "";
+    /**
+     * <code>string test_suite_label = 6;</code>
+     * @return The testSuiteLabel.
+     */
+    @java.lang.Override
+    public java.lang.String getTestSuiteLabel() {
+      java.lang.Object ref = testSuiteLabel_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        testSuiteLabel_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string test_suite_label = 6;</code>
+     * @return The bytes for testSuiteLabel.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTestSuiteLabelBytes() {
+      java.lang.Object ref = testSuiteLabel_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        testSuiteLabel_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -8085,6 +8189,12 @@ public final class BspTargetInfo {
       }
       for (int i = 0; i < scalatestClasspathTargets_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, scalatestClasspathTargets_.getRaw(i));
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testSuiteClass_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, testSuiteClass_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testSuiteLabel_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, testSuiteLabel_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -8115,6 +8225,12 @@ public final class BspTargetInfo {
         size += dataSize;
         size += 1 * getScalatestClasspathTargetsList().size();
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testSuiteClass_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, testSuiteClass_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testSuiteLabel_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, testSuiteLabel_);
+      }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
@@ -8136,6 +8252,10 @@ public final class BspTargetInfo {
           .equals(other.getCompilerClasspathList())) return false;
       if (!getScalatestClasspathTargetsList()
           .equals(other.getScalatestClasspathTargetsList())) return false;
+      if (!getTestSuiteClass()
+          .equals(other.getTestSuiteClass())) return false;
+      if (!getTestSuiteLabel()
+          .equals(other.getTestSuiteLabel())) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -8158,6 +8278,14 @@ public final class BspTargetInfo {
       if (getScalatestClasspathTargetsCount() > 0) {
         hash = (37 * hash) + SCALATEST_CLASSPATH_TARGETS_FIELD_NUMBER;
         hash = (53 * hash) + getScalatestClasspathTargetsList().hashCode();
+      }
+      if (!getTestSuiteClass().isEmpty()) {
+        hash = (37 * hash) + TEST_SUITE_CLASS_FIELD_NUMBER;
+        hash = (53 * hash) + getTestSuiteClass().hashCode();
+      }
+      if (!getTestSuiteLabel().isEmpty()) {
+        hash = (37 * hash) + TEST_SUITE_LABEL_FIELD_NUMBER;
+        hash = (53 * hash) + getTestSuiteLabel().hashCode();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -8355,6 +8483,12 @@ public final class BspTargetInfo {
           scalatestClasspathTargets_.makeImmutable();
           result.scalatestClasspathTargets_ = scalatestClasspathTargets_;
         }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.testSuiteClass_ = testSuiteClass_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.testSuiteLabel_ = testSuiteLabel_;
+        }
       }
 
       @java.lang.Override
@@ -8447,6 +8581,16 @@ public final class BspTargetInfo {
           }
           onChanged();
         }
+        if (!other.getTestSuiteClass().isEmpty()) {
+          testSuiteClass_ = other.testSuiteClass_;
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
+        if (!other.getTestSuiteLabel().isEmpty()) {
+          testSuiteLabel_ = other.testSuiteLabel_;
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
@@ -8498,6 +8642,16 @@ public final class BspTargetInfo {
                 scalatestClasspathTargets_.add(s);
                 break;
               } // case 34
+              case 42: {
+                testSuiteClass_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 42
+              case 50: {
+                testSuiteLabel_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 50
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -8976,6 +9130,150 @@ public final class BspTargetInfo {
         onChanged();
         return this;
       }
+
+      private java.lang.Object testSuiteClass_ = "";
+      /**
+       * <code>string test_suite_class = 5;</code>
+       * @return The testSuiteClass.
+       */
+      public java.lang.String getTestSuiteClass() {
+        java.lang.Object ref = testSuiteClass_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          testSuiteClass_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string test_suite_class = 5;</code>
+       * @return The bytes for testSuiteClass.
+       */
+      public com.google.protobuf.ByteString
+          getTestSuiteClassBytes() {
+        java.lang.Object ref = testSuiteClass_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          testSuiteClass_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string test_suite_class = 5;</code>
+       * @param value The testSuiteClass to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTestSuiteClass(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        testSuiteClass_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string test_suite_class = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTestSuiteClass() {
+        testSuiteClass_ = getDefaultInstance().getTestSuiteClass();
+        bitField0_ = (bitField0_ & ~0x00000008);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string test_suite_class = 5;</code>
+       * @param value The bytes for testSuiteClass to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTestSuiteClassBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        testSuiteClass_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object testSuiteLabel_ = "";
+      /**
+       * <code>string test_suite_label = 6;</code>
+       * @return The testSuiteLabel.
+       */
+      public java.lang.String getTestSuiteLabel() {
+        java.lang.Object ref = testSuiteLabel_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          testSuiteLabel_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string test_suite_label = 6;</code>
+       * @return The bytes for testSuiteLabel.
+       */
+      public com.google.protobuf.ByteString
+          getTestSuiteLabelBytes() {
+        java.lang.Object ref = testSuiteLabel_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          testSuiteLabel_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string test_suite_label = 6;</code>
+       * @param value The testSuiteLabel to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTestSuiteLabel(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        testSuiteLabel_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string test_suite_label = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTestSuiteLabel() {
+        testSuiteLabel_ = getDefaultInstance().getTestSuiteLabel();
+        bitField0_ = (bitField0_ & ~0x00000010);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string test_suite_label = 6;</code>
+       * @param value The bytes for testSuiteLabel to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTestSuiteLabelBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        testSuiteLabel_ = value;
+        bitField0_ |= 0x00000010;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -9118,7 +9416,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pluginId_ = s;
@@ -9134,7 +9432,7 @@ public final class BspTargetInfo {
         getPluginIdBytes() {
       java.lang.Object ref = pluginId_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         pluginId_ = b;
@@ -9157,7 +9455,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         optionValue_ = s;
@@ -9173,7 +9471,7 @@ public final class BspTargetInfo {
         getOptionValueBytes() {
       java.lang.Object ref = optionValue_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         optionValue_ = b;
@@ -9558,7 +9856,7 @@ public final class BspTargetInfo {
           getPluginIdBytes() {
         java.lang.Object ref = pluginId_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           pluginId_ = b;
@@ -9630,7 +9928,7 @@ public final class BspTargetInfo {
           getOptionValueBytes() {
         java.lang.Object ref = optionValue_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           optionValue_ = b;
@@ -11118,7 +11416,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         languageVersion_ = s;
@@ -11134,7 +11432,7 @@ public final class BspTargetInfo {
         getLanguageVersionBytes() {
       java.lang.Object ref = languageVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         languageVersion_ = b;
@@ -11157,7 +11455,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         apiVersion_ = s;
@@ -11173,7 +11471,7 @@ public final class BspTargetInfo {
         getApiVersionBytes() {
       java.lang.Object ref = apiVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         apiVersion_ = b;
@@ -11352,7 +11650,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         moduleName_ = s;
@@ -11368,7 +11666,7 @@ public final class BspTargetInfo {
         getModuleNameBytes() {
       java.lang.Object ref = moduleName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         moduleName_ = b;
@@ -12071,7 +12369,7 @@ public final class BspTargetInfo {
           getLanguageVersionBytes() {
         java.lang.Object ref = languageVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           languageVersion_ = b;
@@ -12143,7 +12441,7 @@ public final class BspTargetInfo {
           getApiVersionBytes() {
         java.lang.Object ref = apiVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           apiVersion_ = b;
@@ -12917,7 +13215,7 @@ public final class BspTargetInfo {
           getModuleNameBytes() {
         java.lang.Object ref = moduleName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           moduleName_ = b;
@@ -15142,7 +15440,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         version_ = s;
@@ -15158,7 +15456,7 @@ public final class BspTargetInfo {
         getVersionBytes() {
       java.lang.Object ref = version_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         version_ = b;
@@ -15285,7 +15583,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         mainModule_ = s;
@@ -15301,7 +15599,7 @@ public final class BspTargetInfo {
         getMainModuleBytes() {
       java.lang.Object ref = mainModule_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         mainModule_ = b;
@@ -16002,7 +16300,7 @@ public final class BspTargetInfo {
           getVersionBytes() {
         java.lang.Object ref = version_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           version_ = b;
@@ -16546,7 +16844,7 @@ public final class BspTargetInfo {
           getMainModuleBytes() {
         java.lang.Object ref = mainModule_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           mainModule_ = b;
@@ -16789,7 +17087,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         importPath_ = s;
@@ -16805,7 +17103,7 @@ public final class BspTargetInfo {
         getImportPathBytes() {
       java.lang.Object ref = importPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         importPath_ = b;
@@ -17427,7 +17725,7 @@ public final class BspTargetInfo {
           getImportPathBytes() {
         java.lang.Object ref = importPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           importPath_ = b;
@@ -18872,7 +19170,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         importPath_ = s;
@@ -18888,7 +19186,7 @@ public final class BspTargetInfo {
         getImportPathBytes() {
       java.lang.Object ref = importPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         importPath_ = b;
@@ -19320,7 +19618,7 @@ public final class BspTargetInfo {
           getImportPathBytes() {
         java.lang.Object ref = importPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           importPath_ = b;
@@ -19949,7 +20247,7 @@ java.lang.String defaultValue);
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         kind_ = s;
@@ -19965,7 +20263,7 @@ java.lang.String defaultValue);
         getKindBytes() {
       java.lang.Object ref = kind_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         kind_ = b;
@@ -20260,7 +20558,7 @@ java.lang.String defaultValue) {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         workspaceName_ = s;
@@ -20276,7 +20574,7 @@ java.lang.String defaultValue) {
         getWorkspaceNameBytes() {
       java.lang.Object ref = workspaceName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         workspaceName_ = b;
@@ -20325,7 +20623,7 @@ java.lang.String defaultValue) {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         generatorName_ = s;
@@ -20341,7 +20639,7 @@ java.lang.String defaultValue) {
         getGeneratorNameBytes() {
       java.lang.Object ref = generatorName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         generatorName_ = b;
@@ -21650,7 +21948,7 @@ java.lang.String defaultValue) {
           getKindBytes() {
         java.lang.Object ref = kind_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           kind_ = b;
@@ -22704,7 +23002,7 @@ java.lang.String defaultValue) {
           getWorkspaceNameBytes() {
         java.lang.Object ref = workspaceName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           workspaceName_ = b;
@@ -22897,7 +23195,7 @@ java.lang.String defaultValue) {
           getGeneratorNameBytes() {
         java.lang.Object ref = generatorName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           generatorName_ = b;
@@ -24099,11 +24397,13 @@ java.lang.String defaultValue) {
       "n\030\001 \001(\t\022\026\n\016target_version\030\002 \001(\t\022-\n\tjava_" +
       "home\030\003 \001(\0132\032.bazelbsp.ArtifactLocation\022<" +
       "\n\030boot_classpath_java_home\030\004 \001(\0132\032.bazel" +
-      "bsp.ArtifactLocation\"\203\001\n\017ScalaTargetInfo" +
+      "bsp.ArtifactLocation\"\267\001\n\017ScalaTargetInfo" +
       "\022\023\n\013scalac_opts\030\001 \003(\t\0226\n\022compiler_classp" +
       "ath\030\002 \003(\0132\032.bazelbsp.ArtifactLocation\022#\n" +
-      "\033scalatest_classpath_targets\030\004 \003(\t\"?\n\023Ko" +
-      "tlincPluginOption\022\021\n\tplugin_id\030d \001(\t\022\025\n\014" +
+      "\033scalatest_classpath_targets\030\004 \003(\t\022\030\n\020te" +
+      "st_suite_class\030\005 \001(\t\022\030\n\020test_suite_label" +
+      "\030\006 \001(\t\"?\n\023KotlincPluginOption\022\021\n\tplugin_" +
+      "id\030d \001(\t\022\025\n\014" +
       "option_value\030\310\001 \001(\t\"\204\001\n\021KotlincPluginInf" +
       "o\022/\n\013plugin_jars\030d \003(\0132\032.bazelbsp.Artifa" +
       "ctLocation\022>\n\026kotlinc_plugin_options\030\310\001 " +
@@ -24208,7 +24508,7 @@ java.lang.String defaultValue) {
     internal_static_bazelbsp_ScalaTargetInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_bazelbsp_ScalaTargetInfo_descriptor,
-        new java.lang.String[] { "ScalacOpts", "CompilerClasspath", "ScalatestClasspathTargets", });
+        new java.lang.String[] { "ScalacOpts", "CompilerClasspath", "ScalatestClasspathTargets", "TestSuiteClass", "TestSuiteLabel", });
     internal_static_bazelbsp_KotlincPluginOption_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_bazelbsp_KotlincPluginOption_fieldAccessorTable = new

--- a/protobuf/src/main/gen/org/jetbrains/bazel/info/BspTargetInfo.java
+++ b/protobuf/src/main/gen/org/jetbrains/bazel/info/BspTargetInfo.java
@@ -132,7 +132,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         relativePath_ = s;
@@ -154,7 +154,7 @@ public final class BspTargetInfo {
         getRelativePathBytes() {
       java.lang.Object ref = relativePath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         relativePath_ = b;
@@ -198,7 +198,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         rootPath_ = s;
@@ -220,7 +220,7 @@ public final class BspTargetInfo {
         getRootPathBytes() {
       java.lang.Object ref = rootPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         rootPath_ = b;
@@ -641,7 +641,7 @@ public final class BspTargetInfo {
           getRelativePathBytes() {
         java.lang.Object ref = relativePath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           relativePath_ = b;
@@ -787,7 +787,7 @@ public final class BspTargetInfo {
           getRootPathBytes() {
         java.lang.Object ref = rootPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           rootPath_ = b;
@@ -1050,7 +1050,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         label_ = s;
@@ -1066,7 +1066,7 @@ public final class BspTargetInfo {
         getLabelBytes() {
       java.lang.Object ref = label_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         label_ = b;
@@ -1151,7 +1151,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         configuration_ = s;
@@ -1172,7 +1172,7 @@ public final class BspTargetInfo {
         getConfigurationBytes() {
       java.lang.Object ref = configuration_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         configuration_ = b;
@@ -1596,7 +1596,7 @@ public final class BspTargetInfo {
           getLabelBytes() {
         java.lang.Object ref = label_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           label_ = b;
@@ -1834,7 +1834,7 @@ public final class BspTargetInfo {
           getConfigurationBytes() {
         java.lang.Object ref = configuration_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           configuration_ = b;
@@ -4532,7 +4532,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         mainClass_ = s;
@@ -4548,7 +4548,7 @@ public final class BspTargetInfo {
         getMainClassBytes() {
       java.lang.Object ref = mainClass_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         mainClass_ = b;
@@ -4616,7 +4616,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         resourceStripPrefix_ = s;
@@ -4632,7 +4632,7 @@ public final class BspTargetInfo {
         getResourceStripPrefixBytes() {
       java.lang.Object ref = resourceStripPrefix_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         resourceStripPrefix_ = b;
@@ -5327,7 +5327,7 @@ public final class BspTargetInfo {
           getMainClassBytes() {
         java.lang.Object ref = mainClass_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           mainClass_ = b;
@@ -5517,7 +5517,7 @@ public final class BspTargetInfo {
           getResourceStripPrefixBytes() {
         java.lang.Object ref = resourceStripPrefix_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           resourceStripPrefix_ = b;
@@ -6831,7 +6831,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         sourceVersion_ = s;
@@ -6847,7 +6847,7 @@ public final class BspTargetInfo {
         getSourceVersionBytes() {
       java.lang.Object ref = sourceVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         sourceVersion_ = b;
@@ -6870,7 +6870,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         targetVersion_ = s;
@@ -6886,7 +6886,7 @@ public final class BspTargetInfo {
         getTargetVersionBytes() {
       java.lang.Object ref = targetVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         targetVersion_ = b;
@@ -7406,7 +7406,7 @@ public final class BspTargetInfo {
           getSourceVersionBytes() {
         java.lang.Object ref = sourceVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           sourceVersion_ = b;
@@ -7478,7 +7478,7 @@ public final class BspTargetInfo {
           getTargetVersionBytes() {
         java.lang.Object ref = targetVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           targetVersion_ = b;
@@ -9416,7 +9416,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pluginId_ = s;
@@ -9432,7 +9432,7 @@ public final class BspTargetInfo {
         getPluginIdBytes() {
       java.lang.Object ref = pluginId_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         pluginId_ = b;
@@ -9455,7 +9455,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         optionValue_ = s;
@@ -9471,7 +9471,7 @@ public final class BspTargetInfo {
         getOptionValueBytes() {
       java.lang.Object ref = optionValue_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         optionValue_ = b;
@@ -9856,7 +9856,7 @@ public final class BspTargetInfo {
           getPluginIdBytes() {
         java.lang.Object ref = pluginId_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           pluginId_ = b;
@@ -9928,7 +9928,7 @@ public final class BspTargetInfo {
           getOptionValueBytes() {
         java.lang.Object ref = optionValue_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           optionValue_ = b;
@@ -11416,7 +11416,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         languageVersion_ = s;
@@ -11432,7 +11432,7 @@ public final class BspTargetInfo {
         getLanguageVersionBytes() {
       java.lang.Object ref = languageVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         languageVersion_ = b;
@@ -11455,7 +11455,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         apiVersion_ = s;
@@ -11471,7 +11471,7 @@ public final class BspTargetInfo {
         getApiVersionBytes() {
       java.lang.Object ref = apiVersion_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         apiVersion_ = b;
@@ -11650,7 +11650,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         moduleName_ = s;
@@ -11666,7 +11666,7 @@ public final class BspTargetInfo {
         getModuleNameBytes() {
       java.lang.Object ref = moduleName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         moduleName_ = b;
@@ -12369,7 +12369,7 @@ public final class BspTargetInfo {
           getLanguageVersionBytes() {
         java.lang.Object ref = languageVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           languageVersion_ = b;
@@ -12441,7 +12441,7 @@ public final class BspTargetInfo {
           getApiVersionBytes() {
         java.lang.Object ref = apiVersion_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           apiVersion_ = b;
@@ -13215,7 +13215,7 @@ public final class BspTargetInfo {
           getModuleNameBytes() {
         java.lang.Object ref = moduleName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           moduleName_ = b;
@@ -15440,7 +15440,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         version_ = s;
@@ -15456,7 +15456,7 @@ public final class BspTargetInfo {
         getVersionBytes() {
       java.lang.Object ref = version_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         version_ = b;
@@ -15583,7 +15583,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         mainModule_ = s;
@@ -15599,7 +15599,7 @@ public final class BspTargetInfo {
         getMainModuleBytes() {
       java.lang.Object ref = mainModule_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         mainModule_ = b;
@@ -16300,7 +16300,7 @@ public final class BspTargetInfo {
           getVersionBytes() {
         java.lang.Object ref = version_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           version_ = b;
@@ -16844,7 +16844,7 @@ public final class BspTargetInfo {
           getMainModuleBytes() {
         java.lang.Object ref = mainModule_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           mainModule_ = b;
@@ -17087,7 +17087,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         importPath_ = s;
@@ -17103,7 +17103,7 @@ public final class BspTargetInfo {
         getImportPathBytes() {
       java.lang.Object ref = importPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         importPath_ = b;
@@ -17725,7 +17725,7 @@ public final class BspTargetInfo {
           getImportPathBytes() {
         java.lang.Object ref = importPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           importPath_ = b;
@@ -19170,7 +19170,7 @@ public final class BspTargetInfo {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         importPath_ = s;
@@ -19186,7 +19186,7 @@ public final class BspTargetInfo {
         getImportPathBytes() {
       java.lang.Object ref = importPath_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         importPath_ = b;
@@ -19618,7 +19618,7 @@ public final class BspTargetInfo {
           getImportPathBytes() {
         java.lang.Object ref = importPath_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           importPath_ = b;
@@ -20247,7 +20247,7 @@ java.lang.String defaultValue);
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         kind_ = s;
@@ -20263,7 +20263,7 @@ java.lang.String defaultValue);
         getKindBytes() {
       java.lang.Object ref = kind_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         kind_ = b;
@@ -20558,7 +20558,7 @@ java.lang.String defaultValue) {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         workspaceName_ = s;
@@ -20574,7 +20574,7 @@ java.lang.String defaultValue) {
         getWorkspaceNameBytes() {
       java.lang.Object ref = workspaceName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         workspaceName_ = b;
@@ -20623,7 +20623,7 @@ java.lang.String defaultValue) {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
+        com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         generatorName_ = s;
@@ -20639,7 +20639,7 @@ java.lang.String defaultValue) {
         getGeneratorNameBytes() {
       java.lang.Object ref = generatorName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
+        com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         generatorName_ = b;
@@ -21948,7 +21948,7 @@ java.lang.String defaultValue) {
           getKindBytes() {
         java.lang.Object ref = kind_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           kind_ = b;
@@ -23002,7 +23002,7 @@ java.lang.String defaultValue) {
           getWorkspaceNameBytes() {
         java.lang.Object ref = workspaceName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           workspaceName_ = b;
@@ -23195,7 +23195,7 @@ java.lang.String defaultValue) {
           getGeneratorNameBytes() {
         java.lang.Object ref = generatorName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           generatorName_ = b;


### PR DESCRIPTION
Import rules_scala suite metadata and use it to rewrite class-level Specs2 gutter filters into the JUnit description shape expected by the Specs2 runner Treat scala_junit_test targets as Scala test targets

~~I bundle jackson-module-kotlin with the connector so TestXmlParser resolves the Kotlin Jackson module from the same plugin classloader as the bundled Jackson XML mapper This looks like a classpath workaround, but it is required for the IDE workflow: after the Specs2 filter is fixed, Bazel passes the test and IDEA otherwise fails while parsing the produced test.xml~~

#BAZEL-3171