### PR TITLE
Set program arguments in BazelGoRunHandler configuration

### DIFF
--- a/golang/intellij.bazel.golang.common/src/debug/BazelGoRunHandler.kt
+++ b/golang/intellij.bazel.golang.common/src/debug/BazelGoRunHandler.kt
@@ -88,6 +88,9 @@ internal class GoRunWithDebugCommandLineState(
         customEnvironment[env.key] = env.value
       }
       isPassParentEnvironment = envVarsData.isPassParentEnvs
+      settings.programArguments?.let {
+        params = it
+      }
     }
   }
 }


### PR DESCRIPTION
When debugging a Bazel go_binary target, the program arguments configured in the
run configuration were silently dropped. The debugged binary started with no
arguments, regardless of what was entered in the "Program arguments" field.

Root cause

GoRunWithDebugCommandLineState.patchAdditionalConfigs() applied the configured
environment variables to the GoApplicationConfiguration but never copied the
program arguments over, so the run config's programArguments never reached the
binary launched under dlv.

I've manually validated the behaviour, and now the arguments are properly set