### PR TITLE
bazel: pass --norun_validations to the sync build

### DIFF
--- a/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/params/BazelFlag.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/bazelrunner/params/BazelFlag.kt
@@ -12,6 +12,8 @@ object BazelFlag {
 
   @JvmStatic fun keepGoing() = flag("keep_going")
 
+  @JvmStatic fun noRunValidations() = flag("norun_validations")
+
   @JvmStatic fun javaTestDebug() = flag("java_debug")
 
   @JvmStatic fun outputGroups(groups: List<String>) = arg("output_groups", groups.joinToString(","))

--- a/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
+++ b/intellij.bazel.connector/src/org/jetbrains/bazel/server/bsp/managers/BazelBspAspectsManager.kt
@@ -5,6 +5,7 @@ import org.jetbrains.bazel.bazelrunner.ShowRepoResult
 import org.jetbrains.bazel.bazelrunner.params.BazelFlag.aspect
 import org.jetbrains.bazel.bazelrunner.params.BazelFlag.buildManualTests
 import org.jetbrains.bazel.bazelrunner.params.BazelFlag.keepGoing
+import org.jetbrains.bazel.bazelrunner.params.BazelFlag.noRunValidations
 import org.jetbrains.bazel.bazelrunner.params.BazelFlag.outputGroups
 import org.jetbrains.bazel.bazelrunner.params.BazelFlag.remoteDownloadOutputsTopLevel
 import org.jetbrains.bazel.commons.BazelInfo
@@ -210,6 +211,8 @@ class BazelBspAspectsManager(
         aspect(aspectsResolver.resolveLabel(aspect)),
         outputGroups(outputGroups),
         keepGoing(),
+        // Validations don't contribute to the project model and only slow down sync, so disable them.
+        noRunValidations(),
       )
     val allowManualTargetsSyncFlags = if (workspaceContext.allowManualTargetsSync) listOf(buildManualTests()) else emptyList()
     val syncFlags = workspaceContext.syncFlags


### PR DESCRIPTION
Pass `--norun_validations` to the Bazel build that runs during project sync as validations typically don't add to the project model and can cause noisy errors during edits.

The new flag is added before `workspaceContext.syncFlags`, so it can still be overridden via project sync flags if needed.
