### PR TITLE
Fix "Go to Definition" for exported `java_library` targets

### DIFF
--- a/integrationTests/test/com/intellij/bazel/test/integration/WorkspaceImportApprovalTests.kt
+++ b/integrationTests/test/com/intellij/bazel/test/integration/WorkspaceImportApprovalTests.kt
@@ -59,6 +59,33 @@ internal class WorkspaceImportApprovalTests {
       ),
       ApprovalTestCase(WorkspaceImportApprovalTestCases.SimpleScalaTest, WorkspaceImportApprovalTestData("SimpleScalaTest")),
 
+      // Regression: a jdeps-derived sourceless library must not shadow an in-project source module.
+      // //src/main/com/example/a:A is an in-scope source module, but import_depth=0 demotes the
+      // re-exporting //src/main/com/example/mid:M to an out-of-scope library, so A's header jar appears
+      // in B's .jdeps without A being on B's transitive dependency path. Before the fix in
+      // JavaLanguagePlugin.jdepsDependencies this leaked A's header jar back in as a sourceless library
+      // that shadowed A's sources; the fix instead emits a non-exported module dependency B -> A. The
+      // golden must contain modules for A, B and C, B depending on A as a (non-exported) module, and NO
+      // sourceless library holding A's header jar. //src/main/com/example/c:C is a dependent of B that
+      // uses A indirectly -- a manual demo that A is unresolved in C (B does not re-export it) and
+      // IntelliJ offers "Add dependency on module 'A'" (it deliberately does not compile).
+      ApprovalTestCase(
+        project = TestCase(
+          ideInfo = IdeInfo.IdeaUltimate,
+          projectInfo = ReusableLocalProjectInfo(
+            projectDir = BazelPathManager.testProjectsRoot.resolve("jdeps_library_shadows_module"),
+          ),
+        ),
+        data = WorkspaceImportApprovalTestData(
+          name = "JdepsLibraryShadowsModule",
+          projectView = { projectDir -> projectDir.resolve(".bazelproject") },
+          onProjectInit = { projectDir ->
+            setupRemoteJdk(projectDir, "21")
+            projectDir.resolve(".bazelversion").writeText("8.7.0")
+          },
+        ),
+      ),
+
       // community
       ApprovalTestCase(
         project = TestCase(

--- a/intellij.bazel.commons/src/org/jetbrains/bazel/label/DependencyLabel.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bazel/label/DependencyLabel.kt
@@ -34,7 +34,19 @@ data class DependencyLabel(
 
 @ApiStatus.Internal
 enum class DependencyLabelKind {
-  COMPILE, EXPORTED_COMPILE_TIME, RUNTIME, TOOLCHAIN
+  COMPILE,
+
+  /**
+   * A compile-scope dependency that is never exported, even for rule kinds whose module dependencies are
+   * otherwise force-exported during resolution. Used for dependencies synthesized from a target's jdeps
+   * that point at another imported target: the consumer must be able to resolve the producer's classes,
+   * but it does not declare or re-export the producer, so the producer must not leak to the consumer's
+   * own dependents.
+   */
+  COMPILE_NON_EXPORTED,
+  EXPORTED_COMPILE_TIME,
+  RUNTIME,
+  TOOLCHAIN,
 }
 
 @ApiStatus.Internal

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/languages/java/JavaLanguagePlugin.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/languages/java/JavaLanguagePlugin.kt
@@ -127,6 +127,7 @@ class JavaLanguagePlugin : LanguagePlugin {
     private var jdk: Jdk? = null
     private var toolchainTargets: Map<Label, TargetInfo> = mapOf()
     private var extraLibDependencies: Map<Label, List<DependencyLabel>> = mapOf()
+    private var extraModuleDependencies: Map<Label, List<DependencyLabel>> = mapOf()
     private var toolchainDependencies: Map<Label, List<DependencyLabel>> = mapOf()
     private var allLibraries: Map<Label, List<LibraryItem>> = mapOf()
 
@@ -199,6 +200,7 @@ class JavaLanguagePlugin : LanguagePlugin {
         // extra libraries can override some library versions, so they should be put before
         jvmDependencies =
           extraLibDependencies[label].orEmpty().map { JvmDependency.LibraryDependency(it) } +
+          extraModuleDependencies[label].orEmpty().map { JvmDependency.ModuleDependency(it) } +
           target.dependencies().map {
             if (targetLibraries.containsKey(it.label))
               JvmDependency.LibraryDependency(it)
@@ -322,19 +324,20 @@ class JavaLanguagePlugin : LanguagePlugin {
           concatenateMaps(listOf(librariesFromDeps, librariesFromToolchains, importDependenciesAsLibraries))
         }
 
-      val extraLibrariesFromJdeps: Map<Label, List<LibraryItem>> =
-        measure("Libraries from jdeps") {
-          jdepsLibraries(
+      val jdepsResult: JdepsDependencies =
+        measure("Dependencies from jdeps") {
+          jdepsDependencies(
             targetsToImport,
             librariesFromDepsAndTargets,
             interfacesAndBinariesFromTargetsToImport,
           )
         }
 
-      val extraLibraries = concatenateMaps(listOf(librariesFromDeps, extraLibrariesFromJdeps))
+      val extraLibraries = concatenateMaps(listOf(librariesFromDeps, jdepsResult.libraries))
 
       extraLibDependencies =
         extraLibraries.mapValues { (_, libs) -> libs.map { DependencyLabel(it.id, kind = DependencyLabelKind.EXPORTED_COMPILE_TIME) } }
+      extraModuleDependencies = jdepsResult.moduleDependencies
       toolchainDependencies = librariesFromToolchains.mapValues { (_, libs) -> libs.map { DependencyLabel(it.id) } }
       allLibraries = concatenateMaps(listOf(importDependenciesAsLibraries, extraLibraries, librariesFromToolchains))
     }
@@ -482,34 +485,63 @@ class JavaLanguagePlugin : LanguagePlugin {
      * The old Bazel Plugin performs similar step here
      * https://github.com/bazelbuild/intellij/blob/b68ec8b33aa54ead6d84dd94daf4822089b3b013/java/src/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporter.java#L256
      */
-    private suspend fun jdepsLibraries(
+    /**
+     * The jdeps-recorded compile dependencies of every imported target, split by how they should be
+     * represented in the workspace model:
+     *  - [libraries]: jars not produced by any imported target become synthetic sourceless libraries.
+     *  - [moduleDependencies]: a jar produced by an imported target becomes a non-exported module
+     *    dependency on that target. Turning it into a sourceless library instead would shadow the target's
+     *    own source module, so go-to-definition would resolve to the decompiled .class.
+     */
+    private class JdepsDependencies(
+      val libraries: Map<Label, List<LibraryItem>>,
+      val moduleDependencies: Map<Label, List<DependencyLabel>>,
+    )
+
+    private suspend fun jdepsDependencies(
       targetsToImport: Map<Label, TargetInfo>,
       libraryDependencies: Map<Label, List<LibraryItem>>,
       interfacesAndBinariesFromTargetsToImport: Map<Label, Set<Path>>,
-    ): Map<Label, List<LibraryItem>> {
+    ): JdepsDependencies {
       val localRepositories = repoMapping.getLocalRepositories()
       val targetsToJdepsJars: Map<Label, Set<Path>> =
         getAllJdepsDependencies(targetsToImport, libraryDependencies, localRepositories)
-      val libraryNameToLibraryValueMap = HashMap<Label, LibraryItem>()
-      return targetsToJdepsJars.mapValues { target: Map.Entry<Label, Set<Path>> ->
-        val interfacesAndBinariesFromTarget =
-          interfacesAndBinariesFromTargetsToImport.getOrDefault(target.key, emptySet())
-        target.value
-          .map { path: Path -> bazelPathsResolver.resolve(path) }
-          .filter { it !in interfacesAndBinariesFromTarget }
-          .mapNotNull {
-            if (shouldSkipJdepsJar(it)) return@mapNotNull null
-            val label = syntheticLabel(it)
-            libraryNameToLibraryValueMap.getOrPut(label) {
-              createLibrary(
-                id = label,
-                ijars = emptySet(),
-                jars = setOf(it),
-                sourceJars = emptySet(),
-              )
-            }
+      // Map every interface/binary jar produced by an imported target back to that target. A .jdeps
+      // reference to such a jar means the consumer compiles against an imported target's classes without
+      // that target being on its transitive dependency path (e.g. it is reached only through an
+      // out-of-scope library). The jar is already provided by the producing target's source module, so we
+      // emit a non-exported module dependency on that target rather than a sourceless library that would
+      // shadow its sources.
+      val importedTargetByJar: Map<Path, Label> =
+        interfacesAndBinariesFromTargetsToImport.entries
+          .flatMap { (label, jars) -> jars.map { it to label } }
+          .toMap()
+      val libraryByLabel = HashMap<Label, LibraryItem>()
+      val libraries = HashMap<Label, List<LibraryItem>>()
+      val moduleDependencies = HashMap<Label, List<DependencyLabel>>()
+      for ((consumer, jars) in targetsToJdepsJars) {
+        val consumerLibraries = mutableListOf<LibraryItem>()
+        val consumerModuleDeps = LinkedHashSet<Label>()
+        for (jar in jars.map { bazelPathsResolver.resolve(it) }) {
+          val producingTarget = importedTargetByJar[jar]
+          if (producingTarget != null) {
+            if (producingTarget != consumer) consumerModuleDeps.add(producingTarget)
+            continue
           }
+          if (shouldSkipJdepsJar(jar)) continue
+          val label = syntheticLabel(jar)
+          consumerLibraries.add(
+            libraryByLabel.getOrPut(label) {
+              createLibrary(id = label, ijars = emptySet(), jars = setOf(jar), sourceJars = emptySet())
+            },
+          )
+        }
+        if (consumerLibraries.isNotEmpty()) libraries[consumer] = consumerLibraries
+        if (consumerModuleDeps.isNotEmpty()) {
+          moduleDependencies[consumer] = consumerModuleDeps.map { DependencyLabel(it, kind = DependencyLabelKind.COMPILE_NON_EXPORTED) }
+        }
       }
+      return JdepsDependencies(libraries, moduleDependencies)
     }
 
     // See https://github.com/bazel-contrib/rules_jvm_external/issues/786

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/snapshot/WorkspaceTargetGraph.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/snapshot/WorkspaceTargetGraph.kt
@@ -247,7 +247,11 @@ object WorkspaceTargetGraphBuilder {
       rootTargetIds = rootTargetIds,
       targetKey2TargetId = targetKey2TargetId,
       id2WorkspaceTarget = id2WorkspaceTarget,
-      id2CompileSuccessors = buildSuccessorIds { it.kind == DependencyLabelKind.COMPILE || it.kind == DependencyLabelKind.EXPORTED_COMPILE_TIME },
+      id2CompileSuccessors = buildSuccessorIds {
+        it.kind == DependencyLabelKind.COMPILE ||
+          it.kind == DependencyLabelKind.COMPILE_NON_EXPORTED ||
+          it.kind == DependencyLabelKind.EXPORTED_COMPILE_TIME
+      },
       id2AllSuccessors = buildSuccessorIds { true },
     )
   }

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/.bazelproject
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/.bazelproject
@@ -1,0 +1,23 @@
+# Reproduces a jdeps-derived sourceless library shadowing an in-project source module.
+#
+# Only //src/main/com/example/a:A and //src/main/com/example/b:B are roots, and
+# import_depth is 0, so only the roots become source modules. //src/main/com/example/mid:M
+# (which `exports` A) is reachable only as a transitive dependency of B, so it is demoted to
+# a library. B compiles against A's class through M's export, so B's .jdeps references A's
+# header jar -- but the importer's transitive-dependency subtraction cannot see through the
+# `mid` library to A. Before the fix in JavaLanguagePlugin.jdepsDependencies, A's header jar
+# therefore leaked into B as a sourceless library while A was also imported as a source module,
+# shadowing A's sources (go-to-definition on A lands in the decompiled .class instead of A.java).
+# The importer must instead recognize that A's header jar belongs to an imported target and emit a
+# module dependency B -> A, so A resolves to its source module.
+directories:
+  .
+
+targets:
+  //src/main/com/example/a:A
+  //src/main/com/example/b:B
+  # Demo: a dependent of B that uses A indirectly. B does not re-export A, so A is unresolved in C and
+  # IntelliJ offers "Add dependency on module 'A'" (which edits c/BUILD). See src/main/com/example/c.
+  //src/main/com/example/c:C
+
+import_depth: 0

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/MODULE.bazel
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "jdeps_shadow",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "rules_java", version = "9.6.1")

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/a/A.java
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/a/A.java
@@ -1,0 +1,5 @@
+package com.example.a;
+
+public class A {
+  public void hello() {}
+}

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/a/BUILD
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/a/BUILD
@@ -1,0 +1,8 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+# In project scope (a root in .bazelproject) -> imported as a source MODULE.
+java_library(
+    name = "A",
+    srcs = ["A.java"],
+    visibility = ["//visibility:public"],
+)

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/b/B.java
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/b/B.java
@@ -1,0 +1,12 @@
+package com.example.b;
+
+import com.example.a.A;
+
+public class B {
+  public void useA() {
+    // Using A (provided transitively via M's `exports`) makes javac record A's header jar
+    // in B's .jdeps, which is what leaks back in as a sourceless library.
+    A a = new A();
+    a.hello();
+  }
+}

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/b/BUILD
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/b/BUILD
@@ -1,0 +1,11 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+# In project scope (a root in .bazelproject) -> imported as a source MODULE.
+# Depends on M (not directly on A); M re-exports A, so B compiles against A's class.
+# B's .jdeps therefore references A's header jar.
+java_library(
+    name = "B",
+    srcs = ["B.java"],
+    visibility = ["//visibility:public"],
+    deps = ["//src/main/com/example/mid:M"],
+)

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/c/BUILD
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/c/BUILD
@@ -1,0 +1,16 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+# Demo of how a DEPENDENT of B sees A.
+# C depends on B and uses A. A reaches B only through M's `exports`, and B does NOT re-export A, so A is
+# not on C's classpath: in the IDE `new A()` is UNRESOLVED (matching Bazel, which fails to build C). That
+# unresolved reference is what surfaces IntelliJ's "Add dependency on module 'A'" quick fix
+# (OrderEntryFix -> BazelProjectModelModifier), which adds //src/main/com/example/a:A to this target's deps.
+# `bazel build` of this target fails the strict-deps check, which is intentional; the workspace-model
+# import does not compile it.
+java_library(
+    name = "C",
+    srcs = ["C.java"],
+    deps = [
+        "//src/main/com/example/b:B",
+    ],
+)

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/c/C.java
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/c/C.java
@@ -1,0 +1,19 @@
+package com.example.c;
+
+import com.example.a.A;
+import com.example.b.B;
+
+// Demo of how a dependent of B sees A. See the BUILD file in this directory.
+public class C {
+  public void use() {
+    // B is a direct dependency -> resolves cleanly.
+    B b = new B();
+    b.useA();
+
+    // A reaches C only indirectly and B does not re-export it, so A is NOT on C's classpath:
+    // `new A()` is unresolved. IntelliJ then offers "Add dependency on module 'A'", which adds
+    // //src/main/com/example/a:A to this target's deps in the BUILD file.
+    A a = new A();
+    a.hello();
+  }
+}

--- a/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/mid/BUILD
+++ b/pluginTests/testData/testProjects/jdeps_library_shadows_module/src/main/com/example/mid/BUILD
@@ -1,0 +1,10 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+# NOT a root in .bazelproject and only reachable as a transitive dep of //src/main/com/example/b:B.
+# With import_depth: 0 it is therefore demoted to a library rather than a source module.
+# It re-exports A so that B can compile against A's class while only depending on M.
+java_library(
+    name = "M",
+    visibility = ["//visibility:public"],
+    exports = ["//src/main/com/example/a:A"],
+)


### PR DESCRIPTION
## Problem

When a target's `.jdeps` references a jar produced by **another imported target** — e.g. a target reached only through an out-of-scope library that re-`exports` it — the importer turned that jar into a synthetic *sourceless* library. Because the producing target is **also** imported as a source module, the library shadowed its sources: go-to-definition on those symbols resolved to the decompiled `.class` instead of the `.java`.

## Fix

`jdepsLibraries` → `jdepsDependencies`: each jdeps jar is mapped back to the imported target that produces it (via the per-target interface/binary jars). If it belongs to an imported target it becomes a **module dependency** on that target instead of a sourceless library, so it resolves to the target's source module.

The edge uses a new `DependencyLabelKind.COMPILE_NON_EXPORTED`: it resolves for the consumer but is **not** re-exported to the consumer's own dependents (`DependencyBuilder` force-exports plain `COMPILE` module deps for Bazel targets; the new kind opts out). So a *dependent* that uses the producer without declaring it stays unresolved, and IntelliJ's existing "Add dependency on module" quick fix (`OrderEntryFix` → `BazelProjectModelModifier`) applies and edits the BUILD file.

## Test

Adds a workspace-import approval test project `jdeps_library_shadows_module`:
- `//…/a:A` (source module) ← `//…/mid:M` (`exports` A; an out-of-scope library at `import_depth: 0`) ← `//…/b:B`. B compiles against A through M's export, so B's `.jdeps` references A's header jar while A is not on B's transitive module path — the leak scenario.
- `//…/c:C` is a manual demo of the dependent behaviour: it uses A indirectly, so A is unresolved in C and the "Add dependency on module 'A'" quick fix applies. It deliberately does not compile (the workspace-model import does not compile it).

The approval golden is generated locally (the suite is local-only); it should show modules A, B and C, B → A as a non-exported module dependency, and no sourceless library for A's header jar.

Draft: golden not yet generated.
