### PR TITLE
Report missing generated source files during sync instead of dropping them silently

### DIFF
--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/mapper/AspectBazelProjectMapper.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/mapper/AspectBazelProjectMapper.kt
@@ -157,11 +157,15 @@ class AspectBazelProjectMapper(
 
   private class MissingFilesReporter(val target: Label) {
     private val missingSources = ArrayList<Path>()
+    private val missingGeneratedSources = ArrayList<Path>()
 
     fun add(src: ArtifactLocation, path: Path) {
-      // Do not report missing generated sources or unknown languages/file types
-      if (missingSources.size < 3 && src.isSource && LanguageClass.fromExtension(path.extension) != null)
-        missingSources.add(path)
+      // Do not report unknown languages/file types
+      if (LanguageClass.fromExtension(path.extension) == null) return
+      val missing = if (src.isSource) missingSources else missingGeneratedSources
+      if (missing.size < 3) {
+        missing.add(path)
+      }
     }
 
     fun report() {
@@ -169,6 +173,12 @@ class AspectBazelProjectMapper(
         logger.warn(
           "target $target has ${missingSources.size} missing source files: " +
           missingSources.joinToString { it.toString() },
+        )
+      }
+      if (missingGeneratedSources.isNotEmpty()) {
+        logger.warn(
+          "target $target has ${missingGeneratedSources.size} generated source files that were not materialized during sync, " +
+          "so they cannot be indexed by the IDE: " + missingGeneratedSources.joinToString { it.toString() },
         )
       }
     }


### PR DESCRIPTION
## Problem

While debugging why code-generated sources do not resolve in the IDE (red squiggles), I traced two symptom classes through the sync pipeline:

1. **Generated Scala does not resolve.** A `genrule`-produced `.scala` file fed into `scala_library.srcs` reaches `TargetIdeInfo.srcsList` with `is_source = false`, but is not part of any output group in the aspect. A normal Resync (`buildProject = false`) only materializes the `intellij-info` and `intellij-sync` output groups, so the generated file never exists on disk at mapping time.
2. `AspectBazelProjectMapper.resolveSourceSet` then drops the file because `path.exists()` is false — and `MissingFilesReporter.add` **deliberately stays silent for generated sources**, so there is no trace of the drop anywhere. (Generated Python via `py_library` works only because `py_info.bzl` registers `PyInfo.transitive_sources` in the sync output group.)

## This PR

Makes the failure observable: `MissingFilesReporter` now also logs a warning for generated source files that were not materialized during sync, instead of silently ignoring them. This would have pointed straight at the root cause.

## Companion fix

The root causes live in the aspect (`JetBrains/intellij-aspect`, consumed via the `intellij_aspect_sdk` pin in `MODULE.bazel`):

- `modules/scala_info.bzl` detects Scala targets solely by the `scala_`/`thrift_` kind prefix, so custom Scala rules get no `scala_target_info` (unlike Java/Kotlin/Python, which detect by provider).
- Generated sources of JVM targets are in no output group, so a sync without a build never materializes them (see above).
- `modules/python_info.bzl` only falls back to PyInfo/runfiles when `srcs` is completely empty, so a custom code-generator rule providing `PyInfo` whose `srcs` holds generator inputs (templates/protos) exposes no Python sources at all.

I have those fixes plus regression tests ready (new fixture tests fail before / pass after; `//testing/tests/{python,scala,java,kotlin}` pass). Once that lands, the `intellij_aspect_sdk` commit pin here needs a bump to pick it up. Happy to open that PR against intellij-aspect as well.
