### PR TITLE
Fix resolution of generated and provider-forwarded code in the IDE

### DIFF
--- a/intellij.bazel.core/resources/intellij.bazel.core.xml
+++ b/intellij.bazel.core/resources/intellij.bazel.core.xml
@@ -483,6 +483,10 @@
       name="BazelQuery"
     />
 
+    <!-- Source jars produced by Bazel rules (e.g. scrooge) use the .srcjar extension;
+         without this mapping library source roots pointing at them cannot be opened. -->
+    <fileType name="ARCHIVE" extensions="srcjar"/>
+
     <lang.parserDefinition
       implementationClass="org.jetbrains.bazel.languages.bazelquery.parser.BazelQueryParserDefinition"
       language="BazelQuery"

--- a/java/intellij.bazel.java.sync/src/workspace/importer/BuilderUtils.kt
+++ b/java/intellij.bazel.java.sync/src/workspace/importer/BuilderUtils.kt
@@ -22,7 +22,7 @@ internal fun String.toResolvedVirtualFileUrl(virtualFileUrlManager: VirtualFileU
 }
 
 internal fun Path.toJarUrlString(): String =
-  if (extension == "jar") {
+  if (extension == "jar" || extension == "srcjar" || extension == "zip") {
     "jar://$this!/"
   } else {
     // There can be other library roots except for jars, e.g., Android resources. Use the file:// scheme then.

--- a/java/intellij.bazel.java.sync/src/workspace/importer/JvmBuildTargetResolver.kt
+++ b/java/intellij.bazel.java.sync/src/workspace/importer/JvmBuildTargetResolver.kt
@@ -394,11 +394,15 @@ class JvmBuildTargetResolver(
     val targetsToJdepsJars: Map<WorkspaceTargetKey, Set<Path>> =
       getAllJdepsDependencies(targetsToImport, libraryDependencies)
     val libraryNameToLibraryValueMap = HashMap<WorkspaceTargetKey, LibraryItem>()
+    // Jars already provided by a known library must not get a second, sourceless
+    // jdeps library: it would compete with the proper library during resolution.
+    val jarsCoveredByLibraries: Set<Path> =
+      libraryDependencies.values.asSequence().flatten().flatMap { it.allJars }.toSet()
     return targetsToJdepsJars.mapValues { target: Map.Entry<WorkspaceTargetKey, Set<Path>> ->
       val interfacesAndBinariesFromTarget =
         interfacesAndBinariesFromTargetsToImport.getOrDefault(target.key, emptySet())
       target.value
-        .filter { it !in interfacesAndBinariesFromTarget }
+        .filter { it !in interfacesAndBinariesFromTarget && it !in jarsCoveredByLibraries }
         .mapNotNull {
           // the synthetic label was precomputed by the plugin (it needs `bazelBin`, only available at map time)
           val label = jdepsLabelByJar[it] ?: return@mapNotNull null

--- a/pluginTests/testData/testProjects/generated_code_resolution/.bazelproject
+++ b/pluginTests/testData/testProjects/generated_code_resolution/.bazelproject
@@ -1,0 +1,3 @@
+derive_targets_from_directories: true
+directories: .
+import_depth: -1

--- a/pluginTests/testData/testProjects/generated_code_resolution/MODULE.bazel
+++ b/pluginTests/testData/testProjects/generated_code_resolution/MODULE.bazel
@@ -1,0 +1,14 @@
+bazel_dep(name = "rules_java", version = "8.16.1")
+bazel_dep(name = "rules_python", version = "1.4.0")
+bazel_dep(name = "rules_scala", version = "7.1.6")
+
+scala_config = use_extension("@rules_scala//scala/extensions:config.bzl", "scala_config")
+scala_config.settings(scala_version = "2.13.17")
+
+scala_deps = use_extension("@rules_scala//scala/extensions:deps.bzl", "scala_deps")
+scala_deps.scala()
+scala_deps.scalatest()
+scala_deps.twitter_scrooge()
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")

--- a/pluginTests/testData/testProjects/generated_code_resolution/README.md
+++ b/pluginTests/testData/testProjects/generated_code_resolution/README.md
@@ -1,0 +1,15 @@
+# Demo project: resolution of generated and provider-forwarded code
+
+Minimal reproduction of the problems fixed in this PR and in
+JetBrains/intellij-aspect#143. Open this directory as a Bazel project, run a
+plain sync (no build) and check the four scenarios. Each maps to commits in
+the PR table.
+
+| Package | Scenario | Broken behavior without the fixes |
+|---|---|---|
+| `genscala`, `genpy` | generated sources | `Data`/`data.D` in the consumers do not resolve at all after a plain sync: the generated files are in no output group and never exist on disk (aspect side) |
+| `genscala`, `genpy` | multi-hop navigation | with only the aspect fixes, go to definition opens the generated file, but inside it `Part`/`part.P` (another generated library) does not resolve: Python navigation lands in hard-link copies outside all content roots, Scala dead-ends in srcjar views because the library-shadows-module index never matches |
+| `thrift` | scrooge sources | `Row` resolves to a decompiled class file; attaching sources manually has no effect. `.srcjar` is not an archive type, its library root is a `file://` URL, and the srcjar is never materialized on sync |
+| `fwdtest` | test classification | `Lib` does not resolve in `Prod.scala` but resolves fine from any test: the library's only visible executable is the same-package sourceless test the codegen macro emits, so it is classified as test sources; the forwarding rule contributes no dependency edges (aspect side), so the production binary is invisible to reachability |
+
+All four resolve correctly with this PR plus intellij-aspect#143.

--- a/pluginTests/testData/testProjects/generated_code_resolution/fwdtest/BUILD
+++ b/pluginTests/testData/testProjects/generated_code_resolution/fwdtest/BUILD
@@ -1,0 +1,42 @@
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test")
+load("//:gen.bzl", "fwd", "gen")
+
+gen(
+    name = "gen_lib",
+    file = "Lib.scala",
+    text = "package demo\n\nobject Lib { val l: Int = 1 }\n",
+)
+
+scala_library(
+    name = "lib",
+    srcs = [":gen_lib"],
+    tags = ["manual"],
+)
+
+gen(
+    name = "gen_lib_test",
+    file = "LibTest.scala",
+    text = "package demo\n\nimport org.scalatest.flatspec.AnyFlatSpec\n\nclass LibTest extends AnyFlatSpec { it should \"work\" in { assert(Lib.l == 1) } }\n",
+)
+
+# same package, no checked-in sources: the shape a codegen macro emits next to
+# its library (scenario 4)
+scala_test(
+    name = "lib_t",
+    srcs = [":gen_lib_test"],
+    tags = ["manual"],
+    deps = [":lib"],
+)
+
+# forwards the library's JavaInfo through a custom attribute, no DefaultInfo
+fwd(
+    name = "lib_fwd",
+    jvm = ":lib",
+)
+
+scala_binary(
+    name = "prod_bin",
+    srcs = ["Prod.scala"],
+    main_class = "demo.Prod",
+    deps = [":lib_fwd"],
+)

--- a/pluginTests/testData/testProjects/generated_code_resolution/fwdtest/Prod.scala
+++ b/pluginTests/testData/testProjects/generated_code_resolution/fwdtest/Prod.scala
@@ -1,0 +1,10 @@
+package demo
+
+// Lib is production code: a non-test binary depends on it through the
+// forwarding rule. Without the fixes the library is classified as test-only
+// (its only visible executable is the same package sourceless test) and Lib
+// does not resolve here at all, while it resolves fine from any test target
+// (scenario 4)
+object Prod {
+  def main(args: Array[String]): Unit = println(Lib.l)
+}

--- a/pluginTests/testData/testProjects/generated_code_resolution/gen.bzl
+++ b/pluginTests/testData/testProjects/generated_code_resolution/gen.bzl
@@ -1,0 +1,35 @@
+"""Minimal code generators mimicking dataset/partition style codegen macros."""
+
+load("@rules_java//java:defs.bzl", "JavaInfo")
+load("@rules_python//python:defs.bzl", "PyInfo")
+
+def _gen_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.file)
+    ctx.actions.write(out, ctx.attr.text)
+    return [DefaultInfo(files = depset([out]))]
+
+gen = rule(
+    implementation = _gen_impl,
+    attrs = {
+        "file": attr.string(mandatory = True),
+        "text": attr.string(mandatory = True),
+    },
+)
+
+def _fwd_impl(ctx):
+    # forwards the providers of the wrapped library through a custom attribute,
+    # deliberately without DefaultInfo, like multi-language dataset rules do
+    providers = []
+    if ctx.attr.jvm:
+        providers.append(ctx.attr.jvm[JavaInfo])
+    if ctx.attr.py:
+        providers.append(ctx.attr.py[PyInfo])
+    return providers
+
+fwd = rule(
+    implementation = _fwd_impl,
+    attrs = {
+        "jvm": attr.label(providers = [JavaInfo]),
+        "py": attr.label(providers = [PyInfo]),
+    },
+)

--- a/pluginTests/testData/testProjects/generated_code_resolution/genpy/BUILD
+++ b/pluginTests/testData/testProjects/generated_code_resolution/genpy/BUILD
@@ -1,0 +1,34 @@
+load("@rules_python//python:defs.bzl", "py_library")
+load("//:gen.bzl", "gen")
+
+gen(
+    name = "gen_part",
+    file = "part.py",
+    text = "P = 1\n",
+)
+
+py_library(
+    name = "part",
+    srcs = [":gen_part"],
+    imports = ["."],
+)
+
+gen(
+    name = "gen_data",
+    file = "data.py",
+    text = "from part import P\n\nD = P + 1\n",
+)
+
+py_library(
+    name = "data",
+    srcs = [":gen_data"],
+    imports = ["."],
+    deps = [":part"],
+)
+
+py_library(
+    name = "consumer",
+    srcs = ["consumer.py"],
+    imports = ["."],
+    deps = [":data"],
+)

--- a/pluginTests/testData/testProjects/generated_code_resolution/genpy/consumer.py
+++ b/pluginTests/testData/testProjects/generated_code_resolution/genpy/consumer.py
@@ -1,0 +1,5 @@
+# go to definition on D must open the generated data.py (scenario 1);
+# inside it, P from the generated part.py must resolve too (scenario 2)
+from data import D
+
+C = D + 1

--- a/pluginTests/testData/testProjects/generated_code_resolution/genscala/BUILD
+++ b/pluginTests/testData/testProjects/generated_code_resolution/genscala/BUILD
@@ -1,0 +1,31 @@
+load("@rules_scala//scala:scala.bzl", "scala_library")
+load("//:gen.bzl", "gen")
+
+gen(
+    name = "gen_part",
+    file = "Part.scala",
+    text = "package demo\n\nobject Part { val p: Int = 1 }\n",
+)
+
+scala_library(
+    name = "part",
+    srcs = [":gen_part"],
+)
+
+gen(
+    name = "gen_data",
+    file = "Data.scala",
+    text = "package demo\n\nobject Data { val d: Int = Part.p + 1 }\n",
+)
+
+scala_library(
+    name = "data",
+    srcs = [":gen_data"],
+    deps = [":part"],
+)
+
+scala_library(
+    name = "consumer",
+    srcs = ["Consumer.scala"],
+    deps = [":data"],
+)

--- a/pluginTests/testData/testProjects/generated_code_resolution/genscala/Consumer.scala
+++ b/pluginTests/testData/testProjects/generated_code_resolution/genscala/Consumer.scala
@@ -1,0 +1,7 @@
+package demo
+
+object Consumer {
+  // go to definition on Data must open the generated Data.scala (scenario 1);
+  // inside it, Part must resolve as well (scenario 2, second hop)
+  val c: Int = Data.d
+}

--- a/pluginTests/testData/testProjects/generated_code_resolution/thrift/BUILD
+++ b/pluginTests/testData/testProjects/generated_code_resolution/thrift/BUILD
@@ -1,0 +1,20 @@
+load("@rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+
+thrift_library(
+    name = "schema",
+    srcs = ["schema.thrift"],
+)
+
+scrooge_scala_library(
+    name = "thriftscala",
+    visibility = ["//visibility:public"],
+    deps = [":schema"],
+)
+
+scala_library(
+    name = "consumer",
+    srcs = ["ThriftConsumer.scala"],
+    deps = [":thriftscala"],
+)

--- a/pluginTests/testData/testProjects/generated_code_resolution/thrift/ThriftConsumer.scala
+++ b/pluginTests/testData/testProjects/generated_code_resolution/thrift/ThriftConsumer.scala
@@ -1,0 +1,9 @@
+package demo
+
+import demo.thriftscala.Row
+
+object ThriftConsumer {
+  // go to definition on Row must open the scrooge generated source, not a
+  // decompiled class file, and without manually attaching sources (scenario 3)
+  val r: Row = Row(id = "x")
+}

--- a/pluginTests/testData/testProjects/generated_code_resolution/thrift/schema.thrift
+++ b/pluginTests/testData/testProjects/generated_code_resolution/thrift/schema.thrift
@@ -1,0 +1,5 @@
+namespace java demo.thriftscala
+
+struct Row {
+  1: required string id
+}

--- a/python/backend/src/BazelPythonWorkspaceImporter.kt
+++ b/python/backend/src/BazelPythonWorkspaceImporter.kt
@@ -37,6 +37,7 @@ import com.jetbrains.python.sdk.PythonSdkType
 import com.jetbrains.python.sdk.createLocalSdkGuessingTypeByPath
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.VisibleForTesting
+import org.jetbrains.bazel.commons.LanguageClass
 import org.jetbrains.bazel.commons.RepoMapping
 import org.jetbrains.bazel.magicmetamodel.formatAsModuleName
 import org.jetbrains.bazel.progress.TaskConsole
@@ -163,6 +164,10 @@ internal class BazelPythonWorkspaceImporter : BazelWorkspaceImporter {
     entitySource: EntitySource,
   ): WorkspaceImporterResult {
     for ((targetKey, target) in allPythonTargets) {
+      // Dual-language targets (e.g. custom rules forwarding both PyInfo and JavaInfo) are
+      // owned by the JVM importer: both importers derive the same module name, so creating
+      // a Python module here would clobber the JVM module and break JVM consumers.
+      if (target.rawBuildTarget.kind.languageClasses.any { it.languageName in JVM_LANGUAGE_NAMES }) continue
       val sourceDeps = pySourceDeps[targetKey] ?: emptyList()
       val sourceDependencyLibrary =
         calculateSourceDependencyLibrary(targetKey, snapshot.repoMapping, sourceDeps, entitySource, vfuManager)
@@ -419,6 +424,10 @@ internal class BazelPythonWorkspaceImporter : BazelWorkspaceImporter {
     moduleNameByKey[this] ?: this.formatAsModuleName(repoMapping)
 }
 
+
+// language name match to avoid a dependency on the java module, where the JVM
+// LanguageClass constants live
+private val JVM_LANGUAGE_NAMES = setOf("java", "kotlin", "scala")
 @ApiStatus.Internal
 @VisibleForTesting
 fun chooseSdkName(interpreter: PythonBinary, projectName: String): String =

--- a/python/backend/src/PythonResolveIndexService.kt
+++ b/python/backend/src/PythonResolveIndexService.kt
@@ -139,7 +139,15 @@ internal class PythonResolveIndexService(private val project: Project) {
         val getSourcesRelativePathToAbsolutePath: Map<Path, Path> =
           extractPythonBuildTarget(target)?.generatedSources?.getFiles()
               ?.associate { path ->
-                path.toExecRootRelativePath() to (outFilesHardLink.createOutputFileHardLink(path) ?: path.toAbsolutePath())
+                // Prefer the real output path: it is the one covered by the module's
+                // content roots (anchored at bazel-bin), so navigation lands in a file
+                // with a module context and references inside it resolve further.
+                // The hard link is only a fallback for files that are not on disk.
+                path.toExecRootRelativePath() to (
+                  path.toAbsolutePath().takeIf { it.exists() }
+                  ?: outFilesHardLink.createOutputFileHardLink(path)
+                  ?: path.toAbsolutePath()
+                )
               }
           ?: emptyMap()
         expandPathsToQualifiedNames(qualifiedNameImportPaths, sourcesRelativePathToAbsolutePath + getSourcesRelativePathToAbsolutePath)


### PR DESCRIPTION
Companion to JetBrains/intellij-aspect#143. Fixes resolution of generated and provider-forwarded code, diagnosed and verified against a production monorepo (generated Scala/Python, scrooge thrift, provider-forwarding custom rules). Runnable repro of all problem classes: `pluginTests/testData/testProjects/generated_code_resolution`.

| Commit | Bug | Fix |
|---|---|---|
| 5e5a6a3 | `.srcjar` is not an archive file type, so `jar://...srcjar!/` sources roots are dead: decompiled view, manual attach fails too | Register `.srcjar` as ARCHIVE (legacy: `BlazeFileTypeFactory`) |
| 47c8c01 | `toJarUrlString()` writes `file://` URLs for `.srcjar`, unusable as sources roots | jar protocol for `jar`, `srcjar`, `zip` (legacy: `LibraryModifier`) |
| a6a2a07 | Jars already provided by a real library get a second sourceless jdeps library that wins resolution | Skip jars covered by known libraries |
| fd81ce7 | Python resolve index maps generated sources to hard-link copies outside all content roots; navigation opens orphan files where nothing resolves | Prefer the real output path, which the module content roots cover |
| 6b9e045 | Python and JVM importers derive the same module name for dual-language targets; the second entity write is rejected (`MutableEntityStorageImpl: symbolicId already exist`), so whichever importer runs second loses its module, nondeterministically per target and sync | Skip such targets in the Python importer, interim until BAZEL-2214. Removing the check was tested on the repro monorepo and breaks resolution randomly |
| 54f37d3 | | Demo project |

Two fixes still needed from intellij-aspect#143: `python_target_info.generated_sources` (feeds the resolve index, `CustomRuleTest` there), and dependency edge serialization for custom attributes, which BAZEL-3364's test classification relies on for provider-forwarding rules.
