### PR TITLE
BAZEL-2087: rerun failed tests from the toolbar with any test runner

### DIFF
--- a/intellij.bazel.core/resources/intellij.bazel.core.xml
+++ b/intellij.bazel.core/resources/intellij.bazel.core.xml
@@ -43,6 +43,10 @@
                     interface="org.jetbrains.bazel.run.test.BazelTestLocatorProvider"
                     dynamic="true"
     />
+    <extensionPoint qualifiedName="org.jetbrains.bazel.testFilterProvider"
+                    interface="org.jetbrains.bazel.run.test.BazelTestFilterProvider"
+                    dynamic="true"
+    />
     <extensionPoint qualifiedName="org.jetbrains.bazel.bzlmodResolver"
                     interface="org.jetbrains.bazel.languages.starlark.bazel.bzlmod.BazelModuleResolver"
                     dynamic="true"

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/BazelCommandLineStateBase.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/BazelCommandLineStateBase.kt
@@ -105,11 +105,12 @@ abstract class BazelCommandLineStateBase(environment: ExecutionEnvironment) : Co
     val actions = createActions(console, handler, executor)
 
     val executionResult = DefaultExecutionResult(console, handler, *actions)
-    if (useJetBrainsTestRunner) {
-      val rerunFailedTestsAction = BazelRerunFailedTestsAction(console)
-      rerunFailedTestsAction.setModelProvider { console.resultsViewer }
-      executionResult.setRestartActions(rerunFailedTestsAction)
-    }
+    // The rerun-failed action works with any test runner: it re-runs by the JetBrains runner's
+    // test unique ids when that runner is used, and by a generic bazel --test_filter otherwise
+    // (see BazelRerunFailedTestsAction).
+    val rerunFailedTestsAction = BazelRerunFailedTestsAction(console)
+    rerunFailedTestsAction.setModelProvider { console.resultsViewer }
+    executionResult.setRestartActions(rerunFailedTestsAction)
     return executionResult
   }
 }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelRerunFailedTestsAction.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelRerunFailedTestsAction.kt
@@ -19,12 +19,19 @@ internal class BazelRerunFailedTestsAction(
 
   override fun getRunProfile(environment: ExecutionEnvironment): MyRunProfile? {
     val configuration = (myConsoleProperties.configuration as? BazelRunConfiguration)?.clone() as? BazelRunConfiguration ?: return null
-    val failedTestIds = getFailedTests(configuration.project).getTestIds()
-    if (failedTestIds.isEmpty()) return null
     val handler = configuration.handler ?: return null
-
     val state = handler.state as? AbstractGenericTestState<*> ?: return null
-    setTestUniqueIds(state = state, testUniqueIds = failedTestIds)
+
+    val failedTests = getFailedTests(configuration.project)
+    if (configuration.project.useJetBrainsTestRunner()) {
+      val failedTestIds = failedTests.getTestIds()
+      if (failedTestIds.isEmpty()) return null
+      setTestUniqueIds(state = state, testUniqueIds = failedTestIds)
+    } else {
+      // Any other runner: re-run the failed tests via a generic bazel --test_filter.
+      val testFilter = failedTestsToFilter(failedTests) ?: return null
+      setTestFilter(configuration.project, state, testFilter)
+    }
     return object : MyRunProfile(configuration) {
       override fun getState(
         executor: Executor,
@@ -41,3 +48,20 @@ internal class BazelRerunFailedTestsAction(
 internal fun List<AbstractTestProxy>.getTestIds(): List<String> =
   filter { it.metainfo == "test" }
   .mapNotNull { it.getUserData(SMTestProxy.NODE_ID) }
+
+/**
+ * Builds a bazel `--test_filter` (an alternation regex) selecting exactly the failed [failedTests],
+ * for runners other than the JetBrains one, using the same per-language formatting as the gutter
+ * and results-tree context menu (see [BazelTestFilterProvider]).
+ *
+ * Only leaf tests are used: [getFailedTests] also returns the defective parent classes/containers,
+ * and turning one of those into a filter (e.g. a bare `FooTest`) would re-run the whole class --
+ * every test in it -- not just the failures. Returns null if nothing matched.
+ */
+internal fun failedTestsToFilter(failedTests: List<AbstractTestProxy>): String? =
+  failedTests
+    .filter { it.isLeaf }
+    .mapNotNull { it.locationUrl?.let(BazelTestFilterProvider::testFilterFor) }
+    .distinct()
+    .joinToString("|")
+    .ifEmpty { null }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelRerunTestConfigurationProducer.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelRerunTestConfigurationProducer.kt
@@ -9,9 +9,16 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.jetbrains.bazel.run.config.BazelRunConfiguration
 import org.jetbrains.bazel.run.config.BazelRunConfigurationType
+import org.jetbrains.bazel.run.state.HasTestFilter
 
 /**
- * Allows right-clicking on a test in the test results and then rerunning it separately from other tests
+ * Allows right-clicking on a test in the test results and then rerunning it separately from other tests.
+ *
+ * Works with any test runner: when the JetBrains custom runner is in use we re-run by the runner's
+ * own test unique ids (via the `JB_TEST_UNIQUE_IDS` env var, see [setTestUniqueIds]); otherwise we
+ * re-run via a generic bazel `--test_filter` (see [setTestFilter]) derived from the selected node's
+ * location by [BazelTestFilterProvider], matching what the gutter "run test" action produces.
+ *
  * @see BazelRerunFailedTestsAction
  * @see com.intellij.execution.junit.UniqueIdConfigurationProducer
  */
@@ -24,11 +31,15 @@ private class BazelRerunTestConfigurationProducer : LazyRunConfigurationProducer
     context: ConfigurationContext,
     sourceElement: Ref<PsiElement>,
   ): Boolean {
-    if (!context.project.useJetBrainsTestRunner()) return false
-    val testIds = getTestIdsFromTestConsole(context)
-    if (testIds.isEmpty()) return false
     val handler = configuration.handler ?: return false
-    setTestUniqueIds(handler.state, testIds.toList())
+    if (context.project.useJetBrainsTestRunner()) {
+      val testIds = getTestIdsFromTestConsole(context)
+      if (testIds.isEmpty()) return false
+      setTestUniqueIds(handler.state, testIds.toList())
+    } else {
+      val testFilter = getTestFilterFromTestConsole(context) ?: return false
+      setTestFilter(context.project, handler.state, testFilter)
+    }
 
     val selectedProxy = context.dataContext.getData(AbstractTestProxy.DATA_KEY)
     if (selectedProxy != null) {
@@ -45,15 +56,34 @@ private class BazelRerunTestConfigurationProducer : LazyRunConfigurationProducer
     configuration: BazelRunConfiguration,
     context: ConfigurationContext,
   ): Boolean {
-    if (!context.project.useJetBrainsTestRunner()) return false
     val state = configuration.handler?.state ?: return false
-    val testIds = getTestUniqueIds(state) ?: return false
-    if (testIds.isEmpty()) return false
-    return getTestIdsFromTestConsole(context) == testIds
+    return if (context.project.useJetBrainsTestRunner()) {
+      val testIds = getTestUniqueIds(state) ?: return false
+      testIds.isNotEmpty() && getTestIdsFromTestConsole(context) == testIds
+    } else {
+      val currentFilter = (state as? HasTestFilter)?.testFilter ?: return false
+      currentFilter.isNotEmpty() && getTestFilterFromTestConsole(context) == currentFilter
+    }
   }
 
   private fun getTestIdsFromTestConsole(context: ConfigurationContext): List<String> =
     context.dataContext.getData(AbstractTestProxy.DATA_KEYS).orEmpty().toList().getTestIds()
+
+  /**
+   * A bazel `--test_filter` selecting exactly the test node(s) currently selected in the results
+   * tree, using the same per-language formatting the gutter uses (see [BazelTestFilterProvider]).
+   * Multiple selected nodes are combined into a single alternation regex. Returns null if no
+   * selected node has a location we can turn into a filter.
+   */
+  private fun getTestFilterFromTestConsole(context: ConfigurationContext): String? {
+    val filters =
+      context.dataContext
+        .getData(AbstractTestProxy.DATA_KEYS)
+        .orEmpty()
+        .mapNotNull { it.locationUrl?.let(BazelTestFilterProvider::testFilterFor) }
+        .distinct()
+    return filters.takeIf { it.isNotEmpty() }?.joinToString("|")
+  }
 
   private fun getConfigurationName(proxy: AbstractTestProxy): String? {
     // For a URL like java:test://com.example.TestClass/testMethod we will return testMethod

--- a/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelTestFilterProvider.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/run/test/BazelTestFilterProvider.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.bazel.run.test
+
+import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Language-specific strategy for turning a test-tree node's location URL (as produced by
+ * [org.jetbrains.bazel.testing.BazelTestLocationHintProvider]) into a bazel `--test_filter` value.
+ *
+ * This lets a single test be re-run from the test results tree (right-click -> "Run") with *any*
+ * test runner, not only the JetBrains custom runner: the JetBrains runner is driven by the
+ * `JB_TEST_UNIQUE_IDS` environment variable (see [setTestUniqueIds]), which no other runner
+ * understands, whereas `--test_filter` (see [setTestFilter]) is a generic bazel flag honored by
+ * the native JUnit runner and by custom runners alike.
+ *
+ * The returned value must match, byte for byte, the `--test_filter` that the language's gutter
+ * "run test" action produces for the same test, so that re-running from the gutter and from the
+ * results-tree context menu behave identically.
+ */
+@ApiStatus.Internal
+interface BazelTestFilterProvider {
+  /**
+   * @param locationUrl the [com.intellij.execution.testframework.AbstractTestProxy.getLocationUrl]
+   *   of a selected test node, e.g. `java:test://com.example.FooTest/it_works`.
+   * @return the `--test_filter` value that selects exactly that test, or `null` if this provider
+   *   does not handle the given location URL.
+   */
+  fun testFilterFromLocationUrl(locationUrl: String): String?
+
+  companion object {
+    val ep: ExtensionPointName<BazelTestFilterProvider> =
+      ExtensionPointName.create("org.jetbrains.bazel.testFilterProvider")
+
+    /** The first non-null filter produced by any registered provider, or `null` if none applies. */
+    fun testFilterFor(locationUrl: String): String? =
+      ep.extensionList.firstNotNullOfOrNull { it.testFilterFromLocationUrl(locationUrl) }
+  }
+}

--- a/java/intellij.bazel.java.core/resources/intellij.bazel.java.core.xml
+++ b/java/intellij.bazel.java.core/resources/intellij.bazel.java.core.xml
@@ -47,6 +47,7 @@
 
   <extensions defaultExtensionNs="org.jetbrains.bazel">
     <testLocatorProvider id="defaultJavaLocator" implementation="org.jetbrains.bazel.jvm.run.JavaTestLocatorProvider"/>
+    <testFilterProvider id="defaultJavaFilter" implementation="org.jetbrains.bazel.jvm.run.JavaTestFilterProvider"/>
     <syntheticRunTargetTemplateGenerator language="JAVA"
                                          implementationClass="org.jetbrains.bazel.java.run.JavaSyntheticRunTargetTemplateGenerator"/>
 

--- a/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
+++ b/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiParameter
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.bazel.jvm.run.javaMethodTestFilter
 import org.jetbrains.bazel.run.test.useJetBrainsTestRunner
 import org.jetbrains.bazel.ui.gutters.BazelRunLineMarkerContributor
 
@@ -35,7 +36,7 @@ open class BazelJavaRunLineMarkerContributor : BazelRunLineMarkerContributor() {
         "$fullyQualifiedClassName:$methodName:$methodParameterTypes"
       } else {
         val className = psiIdentifier.getClassName() ?: return methodName
-        "$className.$methodName$"
+        javaMethodTestFilter(className, methodName)
       }
     } else {
       if (element.project.useJetBrainsTestRunner()) {

--- a/java/intellij.bazel.java.core/src/jvm/run/JavaTestFilterProvider.kt
+++ b/java/intellij.bazel.java.core/src/jvm/run/JavaTestFilterProvider.kt
@@ -1,0 +1,37 @@
+package org.jetbrains.bazel.jvm.run
+
+import org.jetbrains.bazel.run.test.BazelTestFilterProvider
+import org.jetbrains.bazel.testing.BazelTestLocationHintProvider
+
+/**
+ * The bazel `--test_filter` value for running a single Java test method when the JetBrains test
+ * runner is *not* in use. Shared with [org.jetbrains.bazel.java.ui.gutters.BazelJavaRunLineMarkerContributor]
+ * so that the gutter "run test" action and the results-tree context menu produce identical filters.
+ *
+ * The trailing `$` anchors the method name so that filtering for `it_fails` does not also match a
+ * sibling `it_fails_again` (matched as a regex by bazel's `--test_filter`).
+ */
+internal fun javaMethodTestFilter(simpleClassName: String, methodName: String?): String = "$simpleClassName.$methodName$"
+
+internal class JavaTestFilterProvider : BazelTestFilterProvider {
+  override fun testFilterFromLocationUrl(locationUrl: String): String? {
+    val isCase = locationUrl.startsWith("${BazelTestLocationHintProvider.TEST_CASE_PROTOCOL}://")
+    val isSuite = locationUrl.startsWith("${BazelTestLocationHintProvider.TEST_SUITE_PROTOCOL}://")
+    if (!isCase && !isSuite) return null
+
+    val hint = BazelTestLocationHintProvider.parseLocationHint(locationUrl)
+    val suites = hint.classNameOrSuites.filter { it.isNotBlank() }
+    if (suites.isEmpty()) return null
+    val methodName = hint.methodName.ifBlank { null }
+
+    return if (methodName == null) {
+      // Whole-class rerun: mirror the gutter, which emits the JVM class name (nested classes are
+      // joined with '$').
+      suites.joinToString("\$")
+    } else {
+      // Single-method rerun: mirror the gutter, which uses the *simple* class name.
+      val simpleClassName = suites.last().substringAfterLast('.')
+      javaMethodTestFilter(simpleClassName, methodName)
+    }
+  }
+}

--- a/pluginTests/test/org/jetbrains/bazel/run/test/BazelRerunFailedTestsActionTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/run/test/BazelRerunFailedTestsActionTest.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.bazel.run.test
+
+import com.intellij.execution.testframework.sm.runner.SMTestProxy
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class BazelRerunFailedTestsActionTest {
+  private fun leafTest(className: String, methodName: String) =
+    SMTestProxy(methodName, false, "java:test://$className/$methodName")
+
+  private fun classSuite(className: String, vararg tests: SMTestProxy) =
+    SMTestProxy(className.substringAfterLast('.'), true, "java:suite://$className")
+      .apply { tests.forEach { addChild(it) } }
+
+  @Test
+  fun `builds an alternation filter from only the failed leaf tests`() {
+    // getFailedTests returns the defective parent class alongside the failed leaf tests; only the
+    // leaves should reach the filter, otherwise the bare class name would re-run the whole class.
+    val foo = leafTest("com.example.MyTest", "foo")
+    val bar = leafTest("com.example.MyTest", "bar")
+    val suite = classSuite("com.example.MyTest", foo, bar)
+
+    failedTestsToFilter(listOf(suite, foo, bar)) shouldBe "MyTest.foo$|MyTest.bar$"
+  }
+
+  @Test
+  fun `returns null when only non-leaf containers failed`() {
+    val suite = classSuite("com.example.MyTest", leafTest("com.example.MyTest", "foo"))
+
+    failedTestsToFilter(listOf(suite)).shouldBeNull()
+  }
+}


### PR DESCRIPTION
## Problem

The "rerun failed tests" toolbar action in the test results is only usable when `use_jetbrains_test_runner` is enabled: it's attached to the test console only in that case, and `BazelRerunFailedTestsAction` re-runs by the JetBrains runner's test unique ids (`JB_TEST_UNIQUE_IDS`), which no other runner understands.

## Change

- Attach the rerun-failed action for **every** test run in `BazelCommandLineStateBase`, not only when the JetBrains runner is used.
- `BazelRerunFailedTestsAction` now branches on the flag: JetBrains runner → existing unique-ids path; otherwise → build a generic bazel `--test_filter` (an alternation of the failed tests) via `BazelTestFilterProvider` and `setTestFilter`.
- Only **leaf** tests contribute to the filter. `getFailedTests` also returns the defective parent classes/containers, and turning one of those into a filter (e.g. a bare `FooTest`) would re-run the whole class — every test in it — rather than just the failures.

## Testing

- Added `BazelRerunFailedTestsActionTest`, covering `failedTestsToFilter`: leaf-only selection (the defective parent class is dropped), alternation of the failed methods, and `null` when only non-leaf containers failed.
- Manually verified in IntelliJ with `use_jetbrains_test_runner` off: after a run with failures, the rerun-failed button re-runs only the failing leaf tests (`--test_filter=Foo.a$|Foo.b$…`) with no whole-class entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
