### PR TITLE
Fail the sync immediately when a required project view import is missing

### DIFF
--- a/intellij.bazel.backend/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/intellij.bazel.backend/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -28,6 +28,8 @@ import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.coroutines.BazelCoroutineService
 import org.jetbrains.bazel.fus.BazelSyncCollector
 import org.jetbrains.bazel.label.Label
+import org.jetbrains.bazel.languages.projectview.ProjectViewService
+import org.jetbrains.bazel.languages.projectview.unresolvedRequiredImports
 import org.jetbrains.bazel.performance.bspTracer
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.progress.withSubtask
@@ -294,6 +296,16 @@ internal class ProjectSyncTask(
     var shouldUpdateProjectModel = false
     try {
       executePreSyncHooks(progressReporter, taskId)
+
+      // A required `import` in the project view (e.g. `import local.bazelproject`) whose file is
+      // missing leaves the project view effectively empty. Without stopping here the sync still
+      // contacts the Bazel server and tries to resolve configurations/targets from that empty view,
+      // which fails slowly with misleading secondary errors instead of the real cause. Stop now;
+      // the offending import was already reported as an error by ReparseProjectViewFilePreSyncHook.
+      if (project.serviceAsync<ProjectViewService>().projectView.unresolvedRequiredImports().isNotEmpty()) {
+        return ProjectSyncResult(ProjectSyncCompletionResult.FAILURE)
+      }
+
       return BazelServerService.getInstance(project).connection.runWithServer(taskId) { server ->
         server.withOutFileHardLinksSync(projectModelUpdated = { shouldUpdateProjectModel }) {
           server.bazelInfo.release.deprecated()?.let { deprecated ->

--- a/intellij.bazel.commons/src/org/jetbrains/bazel/languages/projectview/ProjectView.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bazel/languages/projectview/ProjectView.kt
@@ -46,3 +46,14 @@ class ProjectView @Internal constructor(
     val EMPTY: ProjectView = ProjectView(mapOf(), listOf())
   }
 }
+
+/**
+ * The required `import` statements (i.e. plain `import`, not `try_import`) whose target file could
+ * not be found. A non-empty result means the project view is incomplete and the sync should be
+ * stopped: otherwise it proceeds over an effectively-empty project view and fails slowly with
+ * misleading errors. See `ReparseProjectViewFilePreSyncHook` (which reports each one) and
+ * `ProjectSyncTask` (which aborts the sync).
+ */
+@Internal
+fun ProjectView.unresolvedRequiredImports(): List<Import.Unresolved> =
+  imports.filterIsInstance<Import.Unresolved>().filter { it.isRequired }

--- a/intellij.bazel.core/src/org/jetbrains/bazel/flow/open/ReparseProjectViewFilePreSyncHook.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/flow/open/ReparseProjectViewFilePreSyncHook.kt
@@ -4,7 +4,7 @@ import com.intellij.build.events.MessageEvent
 import com.intellij.openapi.components.serviceAsync
 import org.jetbrains.bazel.config.BazelPluginBundle
 import org.jetbrains.bazel.languages.projectview.ProjectViewService
-import org.jetbrains.bazel.languages.projectview.imports.Import
+import org.jetbrains.bazel.languages.projectview.unresolvedRequiredImports
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.sync.ProjectPreSyncHook
 import org.jetbrains.bazel.sync.withSubtask
@@ -15,11 +15,7 @@ internal class ReparseProjectViewFilePreSyncHook : ProjectPreSyncHook {
     environment.withSubtask(BazelPluginBundle.message("project.view.validate.subtask")) { taskId ->
       val projectViewService = project.serviceAsync<ProjectViewService>()
       projectViewService.forceReparseCurrentProjectViewFiles()
-      val unresolvedRequiredImports = projectViewService
-        .projectView
-        .imports
-        .filterIsInstance<Import.Unresolved>()
-        .filter { it.isRequired }
+      val unresolvedRequiredImports = projectViewService.projectView.unresolvedRequiredImports()
       unresolvedRequiredImports.forEach {
         project.syncConsole.addDiagnosticMessage(
           taskId = taskId,

--- a/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
+++ b/intellij.bazel.core/src/org/jetbrains/bazel/sync/task/ProjectSyncTask.kt
@@ -30,6 +30,8 @@ import org.jetbrains.bazel.config.rootDir
 import org.jetbrains.bazel.coroutines.BazelCoroutineService
 import org.jetbrains.bazel.fus.BazelSyncCollector
 import org.jetbrains.bazel.label.Label
+import org.jetbrains.bazel.languages.projectview.ProjectViewService
+import org.jetbrains.bazel.languages.projectview.unresolvedRequiredImports
 import org.jetbrains.bazel.performance.bspTracer
 import org.jetbrains.bazel.progress.syncConsole
 import org.jetbrains.bazel.progress.withSubtask
@@ -298,6 +300,16 @@ class ProjectSyncTask(private val project: Project) {
     var shouldUpdateProjectModel = false
     try {
       executePreSyncHooks(progressReporter, taskId)
+
+      // A required `import` in the project view (e.g. `import local.bazelproject`) whose file is
+      // missing leaves the project view effectively empty. Without stopping here the sync still
+      // contacts the Bazel server and tries to resolve configurations/targets from that empty view,
+      // which fails slowly with misleading secondary errors instead of the real cause. Stop now;
+      // the offending import was already reported as an error by ReparseProjectViewFilePreSyncHook.
+      if (project.serviceAsync<ProjectViewService>().projectView.unresolvedRequiredImports().isNotEmpty()) {
+        return ProjectSyncResult(ProjectSyncCompletionResult.FAILURE)
+      }
+
       return BazelServerService.getInstance(project).connection.runWithServer(taskId) { server ->
         server.withOutFileHardLinksSync(projectModelUpdated = { shouldUpdateProjectModel }) {
           server.bazelInfo.release.deprecated()?.let { deprecated ->

--- a/pluginTests/test/org/jetbrains/bazel/languages/projectview/ProjectViewUnresolvedImportsTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/languages/projectview/ProjectViewUnresolvedImportsTest.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.bazel.languages.projectview
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import org.jetbrains.bazel.languages.projectview.imports.Import
+import org.junit.jupiter.api.Test
+
+class ProjectViewUnresolvedImportsTest {
+  private fun projectView(vararg imports: Import) = ProjectView(sections = emptyMap(), imports = imports.toList())
+
+  @Test
+  fun `returns required imports that could not be resolved`() {
+    val requiredMissing = Import.Unresolved("local.bazelproject", position = null, isRequired = true)
+    val optionalMissing = Import.Unresolved("optional.bazelproject", position = null, isRequired = false) // try_import
+
+    projectView(requiredMissing, optionalMissing).unresolvedRequiredImports() shouldContainExactly listOf(requiredMissing)
+  }
+
+  @Test
+  fun `is empty when no required import is unresolved`() {
+    val optionalMissing = Import.Unresolved("optional.bazelproject", position = null, isRequired = false)
+
+    projectView(optionalMissing).unresolvedRequiredImports().shouldBeEmpty()
+    projectView().unresolvedRequiredImports().shouldBeEmpty()
+  }
+}


### PR DESCRIPTION
## Problem

When a project view uses a required `import` (e.g. `.bazelproject` = `import local.bazelproject`) and the imported file does **not** exist, the import is silently dropped and the resulting project view is effectively empty. `ReparseProjectViewFilePreSyncHook` reports the missing import as an error diagnostic — but the sync doesn't stop. It proceeds into the pipeline and **contacts the Bazel server** to resolve configurations/targets over the empty project view.

That work is doomed, and instead of surfacing the real cause it fails slowly with confusing *secondary* errors:
- `ProjectResolver — bazel config invocation failed, falling back to BEP configurations`
- `targetInfos should not be empty`
- `ProjectResolver — Serializer for class 'BazelConfiguration' is not found`

…taking tens of seconds before it finally fails. 

## Fix

Add a pre-sync gate in `ProjectSyncTask`: after the project view is reparsed, if it still has unresolved **required** imports, abort the sync (`FAILURE`) **before contacting the Bazel server**. The offending `import` line was already reported with its file/position by the pre-sync hook, so the user sees the real cause immediately. The check is factored into `ProjectView.unresolvedRequiredImports()`, shared by the hook (reporting) and the gate (aborting).

Result: instead of a doomed server sync with misleading secondary errors, the sync stops near-instantly at the missing-import error.

## Testing

- Added `ProjectViewUnresolvedImportsTest` for `unresolvedRequiredImports()` (required-but-missing is returned; `try_import`-style optional is not).
- Verified in IntelliJ with `.bazelproject` = `import local.bazelproject` and `local.bazelproject` deleted (idea.log timestamps):
  - **Before:** sync reaches the server — `bazel config invocation failed`, `targetInfos should not be empty`, `Serializer for class 'BazelConfiguration' is not found` — and fails after ~30s.
  - **After:** sync aborts at the pre-sync gate immediately, no server contact, surfacing the missing-import error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
