### PR TITLE
Use the fully qualified class name in --test_filter

### DIFF
--- a/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
+++ b/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
@@ -34,7 +34,7 @@ open class BazelJavaRunLineMarkerContributor : BazelRunLineMarkerContributor() {
         val methodParameterTypes = psiIdentifier.getMethodParameterTypes()
         "$fullyQualifiedClassName:$methodName:$methodParameterTypes"
       } else {
-        val className = psiIdentifier.getClassName() ?: return methodName
+        val className = psiIdentifier.getTestFilterClassName() ?: return methodName
         "$className.$methodName$"
       }
     } else {
@@ -42,12 +42,23 @@ open class BazelJavaRunLineMarkerContributor : BazelRunLineMarkerContributor() {
         return psiIdentifier?.getFullyQualifiedClassName()
       }
       return if (psiIdentifier is PsiClass) {
-        psiIdentifier.getFullyQualifiedClassName()
+        psiIdentifier.getTestFilterClassName()
       } else {
         psiIdentifier?.getClassName()
       }
     }
   }
+
+  /**
+   * The class name to put in a `--test_filter`, which is matched as a regex against a test's
+   * `className#methodName`.
+   *
+   * The name is fully qualified, so that identically named test classes in different packages don't
+   * all match the same filter. Any `$` separating a nested class is replaced with `.`, both because
+   * a `$` would otherwise be interpreted as a regex end-of-input anchor, and because `.` then
+   * matches the separator whichever form the test runner reports it in.
+   */
+  private fun PsiElement.getTestFilterClassName(): String? = getFullyQualifiedClassName()?.replace('$', '.')
 
   @ApiStatus.Internal
   protected open fun PsiNameIdentifierOwner.getMethodName(): String? = if (isMethod()) name else null

--- a/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
+++ b/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt
@@ -41,11 +41,7 @@ open class BazelJavaRunLineMarkerContributor : BazelRunLineMarkerContributor() {
       if (element.project.useJetBrainsTestRunner()) {
         return psiIdentifier?.getFullyQualifiedClassName()
       }
-      return if (psiIdentifier is PsiClass) {
-        psiIdentifier.getTestFilterClassName()
-      } else {
-        psiIdentifier?.getClassName()
-      }
+      return psiIdentifier?.getTestFilterClassName()
     }
   }
 

--- a/pluginTests/test/org/jetbrains/bazel/jvm/ui/gutters/BazelRunLineMarkerContributorTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/jvm/ui/gutters/BazelRunLineMarkerContributorTest.kt
@@ -81,7 +81,8 @@ class BazelRunLineMarkerContributorTest : BasePlatformTestCase() {
     val result = runLineMarkerContributor.getSingleTestFilter(psiElement)
 
     // then
-    val expectedSingleTestFilter = "BspJVMRunLineMarkerContributorTestData.should add 1 plus 1$"
+    val expectedSingleTestFilter =
+      "org.jetbrains.bazel.ui.gutters.BspJVMRunLineMarkerContributorTestData.should add 1 plus 1$"
     result shouldBe expectedSingleTestFilter
   }
 
@@ -173,7 +174,8 @@ class BazelRunLineMarkerContributorTest : BasePlatformTestCase() {
     val result = runLineMarkerContributor.getSingleTestFilter(psiElement)
 
     // then
-    val expectedSingleTestFilter = "BspJVMRunLineMarkerContributorTestData.addOnePlusOne$"
+    val expectedSingleTestFilter =
+      "org.jetbrains.bazel.ui.gutters.BspJVMRunLineMarkerContributorTestData.addOnePlusOne$"
     result shouldBe expectedSingleTestFilter
   }
 
@@ -195,6 +197,42 @@ class BazelRunLineMarkerContributorTest : BasePlatformTestCase() {
 
     // then
     val expectedSingleTestFilter = "org.jetbrains.bazel.ui.gutters.BspJVMRunLineMarkerContributorTestData"
+    result shouldBe expectedSingleTestFilter
+  }
+
+  private fun CodeInsightTestFixture.getJavaNestedTestFile(): PsiFile =
+    configureByText(
+      "OuterTestData.java",
+      """
+      package org.jetbrains.bazel.ui.gutters;
+
+      import org.junit.Test;
+
+      public class OuterTestData {
+        public static class NestedTestData {
+          @Test
+          public void nestedTest() {
+            assert(true);
+          }
+        }
+      }
+      """.trimMargin(),
+    )
+
+  @Test
+  fun `should return FQN test filter for Java nested test function`() {
+    // given
+    val testFile = myFixture.getJavaNestedTestFile()
+    val psiElement = PsiUtilCore.getElementAtOffset(testFile, testFile.text.indexOf("nestedTest"))
+    val runLineMarkerContributor = BazelJavaRunLineMarkerContributor()
+
+    // when
+    val result = runLineMarkerContributor.getSingleTestFilter(psiElement)
+
+    // then
+    // the '$' separating the nested class is replaced with '.', which the filter matches as a
+    // wildcard -- a literal '$' would be read as a regex end-of-input anchor and match nothing
+    val expectedSingleTestFilter = "org.jetbrains.bazel.ui.gutters.OuterTestData.NestedTestData.nestedTest$"
     result shouldBe expectedSingleTestFilter
   }
 }

--- a/pluginTests/test/org/jetbrains/bazel/jvm/ui/gutters/BazelRunLineMarkerContributorTest.kt
+++ b/pluginTests/test/org/jetbrains/bazel/jvm/ui/gutters/BazelRunLineMarkerContributorTest.kt
@@ -103,7 +103,7 @@ class BazelRunLineMarkerContributorTest : BasePlatformTestCase() {
     val result = runLineMarkerContributor.getSingleTestFilter(psiElement)
 
     // then
-    val expectedSingleTestFilter = "BspJVMRunLineMarkerContributorTestData"
+    val expectedSingleTestFilter = "org.jetbrains.bazel.ui.gutters.BspJVMRunLineMarkerContributorTestData"
     result shouldBe expectedSingleTestFilter
   }
 


### PR DESCRIPTION
## Problem

Two problems with the `--test_filter` a gutter run produces, both because of the class name it puts in it.

**1. Running a `@Nested` class runs nothing.** A class run emits the JVM name ([`getJvmClassName`](https://github.com/JetBrains/hirschgarten/blob/441725c048859f7fd4697a427d524c63f730acd9/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt#L79)), so for a nested class that's `com.example.Outer$Nested`. The filter is matched as a regex, where `$` means end-of-input, so it matches nothing at all — observed on a JUnit5 project:

```
# clicking the gutter on a @Nested class today
--test_filter=com.example.OuterTest$NestedTest   -> 0 tests run
```

**2. A method filter is ambiguous across packages.** It uses the *simple* class name ([L36-39](https://github.com/JetBrains/hirschgarten/blob/441725c048859f7fd4697a427d524c63f730acd9/java/intellij.bazel.java.core/src/java/ui/gutters/BazelJavaRunLineMarkerContributor.kt#L36-L39)), e.g. `IntegrationTest.myTest$`, so with two identically named test classes in different packages, running one method also runs the other:

| filter | `com.example.IntegrationTest#myTest` | `com.example.sub.IntegrationTest#myTest` |
| --- | --- | --- |
| `IntegrationTest.myTest$` (today) | ✅ matches | ⚠️ also matches |
| `com.example.IntegrationTest.myTest$` (this PR) | ✅ matches | correctly excluded |

That second one is the same problem as [BAZEL-1780](https://youtrack.jetbrains.com/issue/BAZEL-1780) — which fixed a *bare method name* filter matching same-named methods by adding the class name — one level up: the class name itself is ambiguous without its package.

## Change

Use the fully qualified class name for the filter, replacing a nested-class `$` with `.`:

`.` is used rather than escaping the `$`, because it matches the separator whichever form the runner reports it in (binary `Outer$Nested` or dotted `Outer.Nested`), and is consistent with the `.` already used between class and method in this filter.

Both class-run branches now go through the same helper, so the `is PsiClass` distinction is gone and Kotlin class runs are fully qualified as well.

The JetBrains-test-runner path is untouched: it already uses the fully qualified name and is not matched as a regex.

## Testing

`BazelRunLineMarkerContributorTest` is updated for the new filters:

- the Java and Kotlin single-test-method expectations, and the Kotlin test-class expectation, become fully qualified;
- a new case covers a Java `@Nested`-style nested class, asserting the dotted `Outer.Nested.nestedTest$` form.

Note that `bazel build //:plugin-bazel_zip` and the project-structure check pass, but per `docs/dev/development_setup.md` the tests themselves can't be *executed* from a fork, so the expectations above are derived from the emitted filter format rather than from a local run — worth a sanity check when they run in your CI.

Verified by installing the built plugin in IntelliJ on a JUnit5 Bazel project:

```
# @Nested class, before -> 0 tests run
--test_filter=com.datadoghq.junit5.demo.JUnitTest1$NestedTest
# @Nested class, after  -> runs the nested tests
--test_filter=com.datadoghq.junit5.demo.JUnitTest1.NestedTest
```

One open question for reviewers: nested `$` is replaced with `.` (a wildcard) rather than escaped as `\$`. The wildcard also matches a runner that reports the dotted form, and can only ever over-match in a contrived case (a sibling class named `Outer`+any-char+`Nested`); escaping would be exact but fails if a runner reports dotted names. Happy to switch if you prefer the stricter form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
